### PR TITLE
Implement clustered forward lighting with point, spot, and directiona…

### DIFF
--- a/apps/sandbox/src/main.cpp
+++ b/apps/sandbox/src/main.cpp
@@ -10,8 +10,12 @@
 #include <Assisi/Render/DefaultMeshes.hpp>
 #include <Assisi/Render/OpenGL/MeshBuffer.hpp>
 #include <Assisi/Render/Shader.hpp>
+
+#include <glad/glad.h>
 #include <Assisi/Runtime/Camera.hpp>
 #include <Assisi/Runtime/Components.hpp>
+#include <Assisi/Runtime/LightComponents.hpp>
+#include <Assisi/Runtime/LightingSystem.hpp>
 #include <Assisi/Runtime/Renderer.hpp>
 #include <Assisi/Window/Key.hpp>
 
@@ -32,7 +36,8 @@ class SandboxApp : public Assisi::App::Application
     void OnUpdate(float dt);
     void OnRender();
     void OnImGui();
-    void OnResize(int w, int h) override;
+    void OnShutdown() override;
+    void OnResize(int width, int height) override;
 
   private:
     Assisi::ECS::SceneRegistry    _scenes;
@@ -42,7 +47,11 @@ class SandboxApp : public Assisi::App::Application
     Assisi::Render::OpenGL::MeshBuffer _cubeMesh;
     Assisi::Render::Shader             _shader;
     Assisi::Runtime::Camera            _camera;
+    Assisi::Runtime::LightingSystem    _lighting;
     glm::mat4                          _projection{1.f};
+
+    static constexpr float kNearZ = 0.1f;
+    static constexpr float kFarZ  = 200.f;
 
     // Camera control state
     float _yaw         = -116.6f; // initialised in OnStart from camera direction
@@ -51,6 +60,8 @@ class SandboxApp : public Assisi::App::Application
 
     static constexpr float kMoveSpeed        = 8.f;   // units/s
     static constexpr float kMouseSensitivity = 0.1f;  // degrees/pixel
+
+    std::vector<unsigned int>           _testTextures; // owned by sandbox, deleted in OnShutdown
 
     Assisi::Physics::RigidBodyComponent _cubeRb{};
     glm::quat                           _cornerRot{1.f, 0.f, 0.f, 0.f};
@@ -84,12 +95,30 @@ void SandboxApp::OnStart()
 
     _camera = Assisi::Runtime::Camera({5.f, 5.f, 10.f}, {0.f, 0.f, 0.f});
 
+    // Lighting system — must be initialised after the OpenGL context is ready
+    {
+        const auto size = GetWindow().GetFramebufferSize();
+        _projection     = MakeProjection(_fovDegrees, kNearZ, kFarZ);
+        if (!_lighting.Initialize(size.Width, size.Height, kNearZ, kFarZ, _projection))
+        {
+            Assisi::Core::Log::Error("Failed to initialise LightingSystem.");
+            RequestClose();
+            return;
+        }
+        _lighting.SetupMeshShader(_shader);
+    }
+
     // Derive initial yaw/pitch from camera direction so mouse control is consistent.
     const glm::vec3 forward = _camera.ForwardDirection();
     _pitch = glm::degrees(glm::asin(forward.y));
     _yaw   = glm::degrees(glm::atan(forward.z, forward.x));
 
-    _projection = MakeProjection(_fovDegrees);
+    // Directional light (sun)
+    {
+        Assisi::ECS::Entity sun = _scene->Create();
+        std::ignore = _scene->Add<Assisi::Runtime::DirectionalLightComponent>(
+            sun, {.direction = {-0.4f, -1.0f, -0.5f}, .color = {1.f, 1.f, 1.f}, .intensity = 0.5f});
+    }
 
     // Floor — static box
     {
@@ -114,11 +143,110 @@ void SandboxApp::OnStart()
         _cubeRb = _physics.AddBox(_spawnPos, _cornerRot, {0.5f, 0.5f, 0.5f}, Assisi::Physics::BodyMotion::Dynamic);
         std::ignore = _scene->Add<Assisi::Physics::RigidBodyComponent>(cube, _cubeRb);
     }
+
+    // Helper: create a 1×1 sRGB texture for a given colour / value
+    auto makeTex = [&](uint8_t r, uint8_t g, uint8_t b) -> unsigned int
+    {
+        unsigned int id = 0;
+        glGenTextures(1, &id);
+        glBindTexture(GL_TEXTURE_2D, id);
+        const uint8_t px[4] = {r, g, b, 255};
+        glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, 1, 1, 0, GL_RGBA, GL_UNSIGNED_BYTE, px);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+        _testTextures.push_back(id);
+        return id;
+    };
+
+    // Albedos
+    const unsigned int texGold  = makeTex(255, 200,  50); // warm gold
+    const unsigned int texRed   = makeTex(200,  35,  35); // saturated red
+    const unsigned int texBlue  = makeTex( 55, 100, 220); // cool blue
+
+    // Roughness values (R channel used; white = 1.0, black = 0.0)
+    const unsigned int roughLow  = makeTex(  8,   8,   8); // ~0.03 — near-mirror
+    const unsigned int roughHigh = makeTex(245, 245, 245); // ~0.96 — very rough
+    const unsigned int roughMed  = makeTex(128, 128, 128); // ~0.50 — semi-rough
+
+    // Metallic values
+    const unsigned int metalFull = makeTex(255, 255, 255); // 1.0 — fully metallic
+    const unsigned int metalNone = makeTex(  0,   0,   0); // 0.0 — dielectric
+    const unsigned int metalMed  = makeTex(128, 128, 128); // 0.5 — partial
+
+    // --- Test cube 1: polished gold metal (high metallic, near-zero roughness) ---
+    {
+        constexpr glm::vec3 pos{-3.f, 0.5f, -2.f};
+        Assisi::ECS::Entity cube = _scene->Create();
+        std::ignore = _scene->Add<Assisi::Runtime::TransformComponent>(cube, {.position = pos});
+        std::ignore = _scene->Add<Assisi::Runtime::MeshRendererComponent>(
+            cube, {.mesh = &_cubeMesh, .albedoTextureId = texGold,
+                   .metallicTextureId = metalFull, .roughnessTextureId = roughLow});
+        std::ignore = _scene->Add<Assisi::Physics::RigidBodyComponent>(
+            cube, _physics.AddBox(pos, {1.f, 0.f, 0.f, 0.f}, {0.5f, 0.5f, 0.5f},
+                                  Assisi::Physics::BodyMotion::Dynamic));
+    }
+
+    // --- Test cube 2: rough red plastic (no metallic, high roughness) ---
+    {
+        constexpr glm::vec3 pos{0.f, 0.5f, -3.f};
+        Assisi::ECS::Entity cube = _scene->Create();
+        std::ignore = _scene->Add<Assisi::Runtime::TransformComponent>(cube, {.position = pos});
+        std::ignore = _scene->Add<Assisi::Runtime::MeshRendererComponent>(
+            cube, {.mesh = &_cubeMesh, .albedoTextureId = texRed,
+                   .metallicTextureId = metalNone, .roughnessTextureId = roughHigh});
+        std::ignore = _scene->Add<Assisi::Physics::RigidBodyComponent>(
+            cube, _physics.AddBox(pos, {1.f, 0.f, 0.f, 0.f}, {0.5f, 0.5f, 0.5f},
+                                  Assisi::Physics::BodyMotion::Dynamic));
+    }
+
+    // --- Test cube 3: semi-rough blue ceramic (partial metallic, medium roughness) ---
+    {
+        constexpr glm::vec3 pos{3.f, 0.5f, -2.f};
+        Assisi::ECS::Entity cube = _scene->Create();
+        std::ignore = _scene->Add<Assisi::Runtime::TransformComponent>(cube, {.position = pos});
+        std::ignore = _scene->Add<Assisi::Runtime::MeshRendererComponent>(
+            cube, {.mesh = &_cubeMesh, .albedoTextureId = texBlue,
+                   .metallicTextureId = metalMed, .roughnessTextureId = roughMed});
+        std::ignore = _scene->Add<Assisi::Physics::RigidBodyComponent>(
+            cube, _physics.AddBox(pos, {1.f, 0.f, 0.f, 0.f}, {0.5f, 0.5f, 0.5f},
+                                  Assisi::Physics::BodyMotion::Dynamic));
+    }
+
+    // --- Point lights ---
+
+    // White — overhead centre
+    {
+        Assisi::ECS::Entity light = _scene->Create();
+        std::ignore = _scene->Add<Assisi::Runtime::TransformComponent>(
+            light, {.position = {0.f, 4.f, -1.f}});
+        std::ignore = _scene->Add<Assisi::Runtime::PointLightComponent>(
+            light, {.color = {1.f, 1.f, 1.f}, .intensity = 150.f, .radius = 30.f});
+    }
+
+    // Blue — left side
+    {
+        Assisi::ECS::Entity light = _scene->Create();
+        std::ignore = _scene->Add<Assisi::Runtime::TransformComponent>(
+            light, {.position = {-5.f, 2.5f, 0.f}});
+        std::ignore = _scene->Add<Assisi::Runtime::PointLightComponent>(
+            light, {.color = {0.2f, 0.4f, 1.f}, .intensity = 200.f, .radius = 30.f});
+    }
+
+    // Red — right side
+    {
+        Assisi::ECS::Entity light = _scene->Create();
+        std::ignore = _scene->Add<Assisi::Runtime::TransformComponent>(
+            light, {.position = {5.f, 2.5f, 0.f}});
+        std::ignore = _scene->Add<Assisi::Runtime::PointLightComponent>(
+            light, {.color = {1.f, 0.1f, 0.1f}, .intensity = 200.f, .radius = 30.f});
+    }
 }
 
-void SandboxApp::OnResize(int /*w*/, int /*h*/)
+void SandboxApp::OnResize(int width, int height)
 {
-    _projection = MakeProjection(_fovDegrees);
+    _projection = MakeProjection(_fovDegrees, kNearZ, kFarZ);
+    _lighting.Resize(width, height, kNearZ, kFarZ, _projection);
+    _lighting.SetupMeshShader(_shader);
 }
 
 void SandboxApp::OnFixedUpdate(float dt)
@@ -189,19 +317,19 @@ void SandboxApp::OnUpdate(float dt)
         if (scroll != 0.f)
         {
             _fovDegrees = glm::clamp(_fovDegrees - (scroll * 5.f), 10.f, 120.f);
-            _projection = MakeProjection(_fovDegrees);
+            _projection = MakeProjection(_fovDegrees, kNearZ, kFarZ);
         }
     }
 }
 
 void SandboxApp::OnRender()
 {
+    _lighting.Update(*_scene, _camera.ViewMatrix());
+
     _shader.Use();
-    _shader.SetVec3("uViewPos",             _camera.WorldPosition());
-    _shader.SetVec3("uDirLight.direction",  {-0.4f, -1.0f, -0.5f});
-    _shader.SetVec3("uDirLight.color",      {1.0f,  1.0f,  1.0f });
-    _shader.SetFloat("uDirLight.intensity", 3.0f);
-    _shader.SetVec3("uAmbient",             {0.03f, 0.03f, 0.03f});
+    _shader.SetVec3("uViewPos", _camera.WorldPosition());
+    _shader.SetVec3("uAmbient", {0.03f, 0.03f, 0.03f});
+    _shader.SetInt("uDirLightCount", static_cast<int>(_lighting.DirLightCount()));
 
     Assisi::Runtime::DrawScene(*_scene, _camera, _projection, _shader);
 }
@@ -254,6 +382,12 @@ void SandboxApp::OnImGui()
     ImGui::TextDisabled("Mouse: look  |  Scroll: FOV  |  Esc: release / quit");
 
     ImGui::End();
+}
+
+void SandboxApp::OnShutdown()
+{
+    if (!_testTextures.empty())
+        glDeleteTextures(static_cast<int>(_testTextures.size()), _testTextures.data());
 }
 
 // ---------------------------------------------------------------------------

--- a/assets/shaders/cluster_build.comp
+++ b/assets/shaders/cluster_build.comp
@@ -1,0 +1,90 @@
+#version 460 core
+
+/// cluster_build.comp
+/// Computes a view-space AABB for each cluster in the 3-D grid.
+/// Dispatch: (kNumX, kNumY, kNumZ) workgroups with local_size (1,1,1).
+/// Run once on init and again after every viewport / projection change.
+
+layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
+
+struct AABB
+{
+    vec4 minPoint;
+    vec4 maxPoint;
+};
+
+layout(std430, binding = 0) writeonly buffer ClusterAABBs
+{
+    AABB clusterAABBs[];
+};
+
+uniform uvec3 uGridDim;       // e.g. (16, 9, 24)
+uniform vec2  uScreenSize;    // framebuffer size in pixels
+uniform float uNearZ;         // positive near clip distance
+uniform float uFarZ;          // positive far clip distance
+uniform mat4  uInvProjection; // inverse of the projection matrix
+
+// Unproject a screen-space pixel position to a view-space point on the near plane.
+// Camera is at the origin in view space; -Z is forward.
+vec3 screenToViewNear(vec2 screenPos)
+{
+    vec2 ndc  = (screenPos / uScreenSize) * 2.0 - 1.0;
+    vec4 clip = vec4(ndc, -1.0, 1.0); // NDC z = -1  →  near plane
+    vec4 view = uInvProjection * clip;
+    return view.xyz / view.w;
+}
+
+// Scale a view-space direction so its z component equals targetZ.
+// Both dir.z and targetZ are negative (objects in front of camera).
+vec3 rayAtZ(vec3 dir, float targetZ)
+{
+    return dir * (targetZ / dir.z);
+}
+
+void main()
+{
+    uvec3 gid = gl_GlobalInvocationID;
+    if (any(greaterThanEqual(gid, uGridDim)))
+        return;
+
+    // Tile extent in screen pixels
+    vec2 tileSize = uScreenSize / vec2(uGridDim.xy);
+    vec2 tileMin  = vec2(gid.xy) * tileSize;
+    vec2 tileMax  = tileMin + tileSize;
+
+    // Four corner ray directions (view-space points on the near plane)
+    vec3 bl = screenToViewNear(tileMin);
+    vec3 br = screenToViewNear(vec2(tileMax.x, tileMin.y));
+    vec3 tl = screenToViewNear(vec2(tileMin.x, tileMax.y));
+    vec3 tr = screenToViewNear(tileMax);
+
+    // Z-slice depths in view space (negative — camera looks down -Z)
+    float zNear = -uNearZ * pow(uFarZ / uNearZ, float(gid.z)       / float(uGridDim.z));
+    float zFar  = -uNearZ * pow(uFarZ / uNearZ, float(gid.z + 1u)  / float(uGridDim.z));
+
+    // 8 view-space corners of this cluster's frustum sub-volume
+    vec3 corners[8];
+    corners[0] = rayAtZ(bl, zNear);
+    corners[1] = rayAtZ(br, zNear);
+    corners[2] = rayAtZ(tl, zNear);
+    corners[3] = rayAtZ(tr, zNear);
+    corners[4] = rayAtZ(bl, zFar);
+    corners[5] = rayAtZ(br, zFar);
+    corners[6] = rayAtZ(tl, zFar);
+    corners[7] = rayAtZ(tr, zFar);
+
+    vec3 aabbMin = corners[0];
+    vec3 aabbMax = corners[0];
+    for (int i = 1; i < 8; i++)
+    {
+        aabbMin = min(aabbMin, corners[i]);
+        aabbMax = max(aabbMax, corners[i]);
+    }
+
+    uint idx = gid.x
+             + gid.y * uGridDim.x
+             + gid.z * uGridDim.x * uGridDim.y;
+
+    clusterAABBs[idx].minPoint = vec4(aabbMin, 0.0);
+    clusterAABBs[idx].maxPoint = vec4(aabbMax, 0.0);
+}

--- a/assets/shaders/cluster_cull.comp
+++ b/assets/shaders/cluster_cull.comp
@@ -1,0 +1,117 @@
+#version 460 core
+
+/// cluster_cull.comp
+/// Tests every light against every cluster AABB (sphere-vs-AABB test) and
+/// writes per-cluster light index lists into a shared flat buffer.
+/// Dispatch: (kNumX, kNumY, kNumZ) workgroups with local_size (1,1,1).
+/// Run every frame, after uploading light data to the light SSBOs.
+
+layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
+
+// Maximum lights tracked per cluster in local scratch arrays.
+// Lights beyond this cap are silently ignored for that cluster.
+#define MAX_LIGHTS_PER_CLUSTER 64
+
+// Flat buffer offset where spot light indices start.
+// Must match ClusterGrid::kMaxLightIndices.
+#define MAX_LIGHT_INDICES 65536
+
+// ---- Structs (must match ClusterGrid GPU structs) ----
+
+struct AABB        { vec4 minPoint; vec4 maxPoint; };
+
+struct PointLight  { vec4 positionRadius; vec4 colorIntensity; };
+
+struct SpotLight
+{
+    vec4  positionRadius;
+    vec4  directionInner;
+    vec4  colorIntensity;
+    float outerCutoff;
+    float _p0, _p1, _p2;
+};
+
+struct LightGrid
+{
+    uint pointOffset;
+    uint pointCount;
+    uint spotOffset;
+    uint spotCount;
+};
+
+// ---- SSBOs ----
+
+layout(std430, binding = 0) readonly  buffer ClusterAABBs   { AABB       clusterAABBs[];   };
+layout(std430, binding = 1) readonly  buffer PointLights    { PointLight  pointLights[];    };
+layout(std430, binding = 2) readonly  buffer SpotLights     { SpotLight   spotLights[];     };
+layout(std430, binding = 4) writeonly buffer LightIndexList { uint        lightIndexList[];  };
+layout(std430, binding = 5) writeonly buffer LightGrids     { LightGrid   lightGrids[];     };
+layout(std430, binding = 6) coherent  buffer GlobalCount    { uint globalPointCount; uint globalSpotCount; };
+
+uniform uvec3 uGridDim;
+uniform uint  uPointLightCount;
+uniform uint  uSpotLightCount;
+uniform mat4  uView; // transforms world-space light positions to view space
+
+// ---- Helpers ----
+
+bool sphereVsAABB(vec3 center, float radius, vec3 aabbMin, vec3 aabbMax)
+{
+    vec3 closest = clamp(center, aabbMin, aabbMax);
+    vec3 d       = closest - center;
+    return dot(d, d) <= radius * radius;
+}
+
+void main()
+{
+    uvec3 gid = gl_GlobalInvocationID;
+    if (any(greaterThanEqual(gid, uGridDim)))
+        return;
+
+    uint clusterIdx = gid.x
+                    + gid.y * uGridDim.x
+                    + gid.z * uGridDim.x * uGridDim.y;
+
+    vec3 cMin = clusterAABBs[clusterIdx].minPoint.xyz;
+    vec3 cMax = clusterAABBs[clusterIdx].maxPoint.xyz;
+
+    // ---- Point lights ----
+    uint localPointIdx[MAX_LIGHTS_PER_CLUSTER];
+    uint pointCount = 0u;
+    for (uint i = 0u; i < uPointLightCount && pointCount < MAX_LIGHTS_PER_CLUSTER; i++)
+    {
+        vec3  viewPos = vec3(uView * vec4(pointLights[i].positionRadius.xyz, 1.0));
+        float radius  = pointLights[i].positionRadius.w;
+        if (sphereVsAABB(viewPos, radius, cMin, cMax))
+            localPointIdx[pointCount++] = i;
+    }
+
+    // ---- Spot lights (culled by bounding sphere for simplicity) ----
+    uint localSpotIdx[MAX_LIGHTS_PER_CLUSTER];
+    uint spotCount = 0u;
+    for (uint i = 0u; i < uSpotLightCount && spotCount < MAX_LIGHTS_PER_CLUSTER; i++)
+    {
+        vec3  viewPos = vec3(uView * vec4(spotLights[i].positionRadius.xyz, 1.0));
+        float radius  = spotLights[i].positionRadius.w;
+        if (sphereVsAABB(viewPos, radius, cMin, cMax))
+            localSpotIdx[spotCount++] = i;
+    }
+
+    // ---- Atomically reserve slots in the global index list ----
+    uint pointOffset = 0u;
+    uint spotOffset  = 0u;
+    if (pointCount > 0u) pointOffset = atomicAdd(globalPointCount, pointCount);
+    if (spotCount  > 0u) spotOffset  = atomicAdd(globalSpotCount,  spotCount);
+
+    // Point indices occupy [0, MAX_LIGHT_INDICES); spot indices start at MAX_LIGHT_INDICES.
+    for (uint i = 0u; i < pointCount; i++)
+        lightIndexList[pointOffset + i] = localPointIdx[i];
+    for (uint i = 0u; i < spotCount; i++)
+        lightIndexList[MAX_LIGHT_INDICES + spotOffset + i] = localSpotIdx[i];
+
+    // ---- Write light grid entry for this cluster ----
+    lightGrids[clusterIdx].pointOffset = pointOffset;
+    lightGrids[clusterIdx].pointCount  = pointCount;
+    lightGrids[clusterIdx].spotOffset  = spotOffset;
+    lightGrids[clusterIdx].spotCount   = spotCount;
+}

--- a/assets/shaders/mesh.frag
+++ b/assets/shaders/mesh.frag
@@ -1,30 +1,72 @@
 #version 460 core
 
-in vec3 vFragPos;
-in vec2 vTexCoords;
-in mat3 vTBN;
+in vec3  vFragPos;
+in vec2  vTexCoords;
+in mat3  vTBN;
+in float vViewZ; // view-space Z (negative for geometry in front of camera)
 
 out vec4 FragColor;
 
+// ---- Light structs (must match ClusterGrid GPU structs exactly) ------------
+
+struct PointLight
+{
+    vec4 positionRadius; // xyz = world pos, w = radius
+    vec4 colorIntensity; // xyz = colour,    w = intensity
+};
+
+struct SpotLight
+{
+    vec4  positionRadius; // xyz = world pos,       w = radius
+    vec4  directionInner; // xyz = direction (unit), w = cos(innerAngle)
+    vec4  colorIntensity; // xyz = colour,           w = intensity
+    float outerCutoff;
+    float _p0, _p1, _p2;
+};
+
 struct DirLight
 {
-    vec3  direction;
-    vec3  color;
-    float intensity;
+    vec4 directionIntensity; // xyz = direction toward light, w = intensity
+    vec4 colorPad;           // xyz = colour, w = unused
 };
+
+struct LightGrid
+{
+    uint pointOffset;
+    uint pointCount;
+    uint spotOffset;
+    uint spotCount;
+};
+
+// ---- SSBOs (binding points match ClusterGrid constants) --------------------
+
+layout(std430, binding = 1) readonly buffer PointLights    { PointLight  pointLights[];    };
+layout(std430, binding = 2) readonly buffer SpotLights     { SpotLight   spotLights[];     };
+layout(std430, binding = 3) readonly buffer DirLights      { DirLight    dirLights[];      };
+layout(std430, binding = 4) readonly buffer LightIndexList { uint        lightIndexList[];  };
+layout(std430, binding = 5) readonly buffer LightGrids     { LightGrid   lightGrids[];     };
+
+// ---- Uniforms --------------------------------------------------------------
 
 uniform sampler2D uAlbedo;
 uniform sampler2D uNormal;
 uniform sampler2D uMetallic;
 uniform sampler2D uRoughness;
 
-uniform vec3     uViewPos;
-uniform vec3     uAmbient;
-uniform DirLight uDirLight;
+uniform vec3 uViewPos;
+uniform vec3 uAmbient;
+uniform int  uDirLightCount;
+
+// Cluster grid parameters (set by LightingSystem::SetupMeshShader)
+uniform uvec3 uGridDim;
+uniform vec2  uScreenSize;
+uniform float uNearZ;
+uniform float uFarZ;
+
+// ---- PBR helpers -----------------------------------------------------------
 
 const float PI = 3.14159265359;
 
-// GGX / Trowbridge-Reitz normal distribution function
 float DistributionGGX(vec3 N, vec3 H, float roughness)
 {
     float a      = roughness * roughness;
@@ -35,7 +77,6 @@ float DistributionGGX(vec3 N, vec3 H, float roughness)
     return a2 / (PI * denom * denom);
 }
 
-// Schlick-GGX geometry term (single direction)
 float GeometrySchlickGGX(float NdotV, float roughness)
 {
     float r = roughness + 1.0;
@@ -43,7 +84,6 @@ float GeometrySchlickGGX(float NdotV, float roughness)
     return NdotV / (NdotV * (1.0 - k) + k);
 }
 
-// Smith's combined geometry term
 float GeometrySmith(vec3 N, vec3 V, vec3 L, float roughness)
 {
     float NdotV = max(dot(N, V), 0.0);
@@ -51,47 +91,140 @@ float GeometrySmith(vec3 N, vec3 V, vec3 L, float roughness)
     return GeometrySchlickGGX(NdotV, roughness) * GeometrySchlickGGX(NdotL, roughness);
 }
 
-// Schlick Fresnel approximation
 vec3 FresnelSchlick(float cosTheta, vec3 F0)
 {
     return F0 + (1.0 - F0) * pow(clamp(1.0 - cosTheta, 0.0, 1.0), 5.0);
 }
 
+// ---- Cook-Torrance BRDF ---------------------------------------------------
+
+vec3 CookTorrance(vec3 N, vec3 V, vec3 L, vec3 radiance,
+                  vec3 albedo, float metallic, float roughness, vec3 F0)
+{
+    float NdotL = max(dot(N, L), 0.0);
+    if (NdotL == 0.0)
+        return vec3(0.0);
+
+    vec3  H        = normalize(V + L);
+    float NDF      = DistributionGGX(N, H, roughness);
+    float G        = GeometrySmith(N, V, L, roughness);
+    vec3  F        = FresnelSchlick(max(dot(H, V), 0.0), F0);
+    vec3  specular = (NDF * G * F) / (4.0 * max(dot(N, V), 0.0) * NdotL + 0.0001);
+    vec3  kD       = (1.0 - F) * (1.0 - metallic);
+    return (kD * albedo / PI + specular) * radiance * NdotL;
+}
+
+// ---- Windowed inverse-square attenuation (Frostbite) ----------------------
+// Returns 0 at dist >= radius, physically plausible inside.
+
+float Attenuation(float dist, float radius)
+{
+    float ratio  = dist / radius;
+    float ratio4 = ratio * ratio * ratio * ratio;
+    float numer  = max(1.0 - ratio4, 0.0);
+    return (numer * numer) / (dist * dist + 1.0);
+}
+
+// ---- Cluster index ---------------------------------------------------------
+
+uint ClusterIndex()
+{
+    uint ix = clamp(uint(gl_FragCoord.x / uScreenSize.x * float(uGridDim.x)),
+                    0u, uGridDim.x - 1u);
+    uint iy = clamp(uint(gl_FragCoord.y / uScreenSize.y * float(uGridDim.y)),
+                    0u, uGridDim.y - 1u);
+
+    // Logarithmic depth slice (abs because vViewZ is negative for visible geometry)
+    float viewDepth = abs(vViewZ);
+    uint  iz = clamp(uint(log(viewDepth / uNearZ) / log(uFarZ / uNearZ) * float(uGridDim.z)),
+                     0u, uGridDim.z - 1u);
+
+    return ix + iy * uGridDim.x + iz * uGridDim.x * uGridDim.y;
+}
+
+// ---- Main ------------------------------------------------------------------
+
 void main()
 {
     // Sample material textures
-    vec3  albedo    = pow(texture(uAlbedo, vTexCoords).rgb, vec3(2.2)); // sRGB -> linear
-    float metallic  = texture(uMetallic, vTexCoords).r;
+    vec3  albedo    = pow(texture(uAlbedo,    vTexCoords).rgb, vec3(2.2)); // sRGB → linear
+    float metallic  = texture(uMetallic,  vTexCoords).r;
     float roughness = texture(uRoughness, vTexCoords).r;
 
-    // Reconstruct world-space normal from normal map
+    // World-space normal from normal map
     vec3 normalTs = texture(uNormal, vTexCoords).rgb * 2.0 - 1.0;
-    vec3 N        = normalize(vTBN * normalTs);
-    vec3 V        = normalize(uViewPos - vFragPos);
+    vec3 N = normalize(vTBN * normalTs);
+    vec3 V = normalize(uViewPos - vFragPos);
 
     // Base reflectance: 0.04 for dielectrics, albedo tint for metals
     vec3 F0 = mix(vec3(0.04), albedo, metallic);
 
-    // --- Directional light contribution ---
-    vec3  L        = normalize(-uDirLight.direction);
-    vec3  H        = normalize(V + L);
-    vec3  radiance = uDirLight.color * uDirLight.intensity;
-    float NdotL    = max(dot(N, L), 0.0);
+    vec3 Lo = vec3(0.0);
 
-    float NDF = DistributionGGX(N, H, roughness);
-    float G   = GeometrySmith(N, V, L, roughness);
-    vec3  F   = FresnelSchlick(max(dot(H, V), 0.0), F0);
+    // ---- Directional lights (no position, no falloff) ----------------------
+    for (int i = 0; i < uDirLightCount; i++)
+    {
+        vec3 L        = normalize(-dirLights[i].directionIntensity.xyz);
+        vec3 radiance = dirLights[i].colorPad.xyz * dirLights[i].directionIntensity.w;
+        Lo += CookTorrance(N, V, L, radiance, albedo, metallic, roughness, F0);
+    }
 
-    vec3 specular = (NDF * G * F) / (4.0 * max(dot(N, V), 0.0) * NdotL + 0.0001);
-    vec3 kD       = (1.0 - F) * (1.0 - metallic);
-    vec3 Lo       = (kD * albedo / PI + specular) * radiance * NdotL;
+    // ---- Clustered point + spot lights ------------------------------------
+    uint clusterIdx  = ClusterIndex();
+    uint pointOffset = lightGrids[clusterIdx].pointOffset;
+    uint pointCount  = lightGrids[clusterIdx].pointCount;
+    uint spotOffset  = lightGrids[clusterIdx].spotOffset;
+    uint spotCount   = lightGrids[clusterIdx].spotCount;
 
-    // Flat ambient (no IBL yet)
-    vec3 ambient = uAmbient * albedo;
+    for (uint i = 0u; i < pointCount; i++)
+    {
+        uint  li       = lightIndexList[pointOffset + i];
+        vec3  lPos     = pointLights[li].positionRadius.xyz;
+        float r        = pointLights[li].positionRadius.w;
+        vec3  lCol     = pointLights[li].colorIntensity.xyz;
+        float lInt     = pointLights[li].colorIntensity.w;
 
-    vec3 color = ambient + Lo;
+        vec3  toLight  = lPos - vFragPos;
+        float dist     = length(toLight);
+        vec3  L        = toLight / dist;
+        float att      = Attenuation(dist, r);
+        vec3  radiance = lCol * lInt * att;
 
-    // Reinhard tone map + gamma correction (no HDR buffer yet)
+        Lo += CookTorrance(N, V, L, radiance, albedo, metallic, roughness, F0);
+    }
+
+    // Spot light indices are offset by MAX_LIGHT_INDICES in the shared buffer
+    // (must match cluster_cull.comp #define MAX_LIGHT_INDICES 65536)
+    const uint kSpotBase = 65536u;
+    for (uint i = 0u; i < spotCount; i++)
+    {
+        uint  li       = lightIndexList[kSpotBase + spotOffset + i];
+        vec3  lPos     = spotLights[li].positionRadius.xyz;
+        float r        = spotLights[li].positionRadius.w;
+        vec3  lDir     = spotLights[li].directionInner.xyz;  // unit, world space
+        float inner    = spotLights[li].directionInner.w;    // cos(innerAngle)
+        vec3  lCol     = spotLights[li].colorIntensity.xyz;
+        float lInt     = spotLights[li].colorIntensity.w;
+        float outer    = spotLights[li].outerCutoff;
+
+        vec3  toLight  = lPos - vFragPos;
+        float dist     = length(toLight);
+        vec3  L        = toLight / dist;
+
+        // Cone attenuation: 1 inside inner cone, smooth falloff to outer, 0 outside
+        float theta    = dot(L, normalize(-lDir));
+        float cone     = smoothstep(outer, inner, theta);
+
+        float att      = Attenuation(dist, r) * cone;
+        vec3  radiance = lCol * lInt * att;
+
+        Lo += CookTorrance(N, V, L, radiance, albedo, metallic, roughness, F0);
+    }
+
+    // ---- Flat ambient + tone map ------------------------------------------
+    vec3 color = uAmbient * albedo + Lo;
+
+    // Reinhard tone map + gamma correction
     color = color / (color + vec3(1.0));
     color = pow(color, vec3(1.0 / 2.2));
 

--- a/assets/shaders/mesh.vert
+++ b/assets/shaders/mesh.vert
@@ -9,9 +9,10 @@ uniform mat4 uModel;
 uniform mat4 uView;
 uniform mat4 uProjection;
 
-out vec3 vFragPos;
-out vec2 vTexCoords;
-out mat3 vTBN;
+out vec3  vFragPos;
+out vec2  vTexCoords;
+out mat3  vTBN;
+out float vViewZ; // view-space Z, used for cluster index computation
 
 void main()
 {
@@ -25,5 +26,8 @@ void main()
     vec3 B = cross(N, T) * aTangent.w;
     vTBN   = mat3(T, B, N);
 
-    gl_Position = uProjection * uView * vec4(vFragPos, 1.0);
+    vec4 viewPos = uView * vec4(vFragPos, 1.0);
+    vViewZ       = viewPos.z; // negative for objects in front of camera
+
+    gl_Position = uProjection * viewPos;
 }

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -8,6 +8,10 @@ joltphysics/5.2.0
 imgui/1.92.5
 nlohmann_json/3.11.3
 
+[options]
+glad*:gl_version=4.6
+glad*:gl_profile=core
+
 [generators]
 CMakeDeps
 CMakeToolchain

--- a/modules/Render/CMakeLists.txt
+++ b/modules/Render/CMakeLists.txt
@@ -13,8 +13,11 @@ target_sources(Assisi-Render
     "include/Assisi/Render/MeshData.hpp"
     "include/Assisi/Render/RenderSystem.hpp"
     "include/Assisi/Render/Shader.hpp"
+    "include/Assisi/Render/ComputeShader.hpp"
+    "include/Assisi/Render/ClusterGrid.hpp"
   PRIVATE
     "src/Shader.cpp"
+    "src/ClusterGrid.cpp"
     "src/Buffer.cpp"
     "src/DefaultResources.cpp"
     "src/RenderSystemOpenGL.cpp"

--- a/modules/Render/include/Assisi/Render/ClusterGrid.hpp
+++ b/modules/Render/include/Assisi/Render/ClusterGrid.hpp
@@ -1,0 +1,130 @@
+/* Copyright (c) 2025 Francisco Vivas Puerto (aka "DaFrancc"). */
+#pragma once
+
+/// @file ClusterGrid.hpp
+/// @brief Clustered forward lighting pipeline.
+///
+/// Divides the view frustum into a 3-D grid (16 × 9 × 24 = 3 456 clusters).
+/// A compute pass builds view-space AABBs once per resize, and a second
+/// compute pass assigns lights to clusters every frame.  The resulting SSBOs
+/// are bound to fixed binding points so the mesh fragment shader can look up
+/// only the lights that touch each fragment's cluster.
+///
+/// Usage (per frame):
+///   1. grid.CullLights(pointLights, spotLights, dirLights, viewMatrix);
+///   2. DrawScene(...)  — mesh.frag reads SSBOs already bound by step 1.
+
+#include <Assisi/Math/GLM.hpp>
+#include <Assisi/Render/ComputeShader.hpp>
+
+#include <cstdint>
+#include <vector>
+
+namespace Assisi::Render
+{
+
+// ---- GPU-side light structs (std430 layout) --------------------------------
+// All vec3 fields are stored in vec4 to satisfy std430 alignment rules.
+// The C++ structs must have identical memory layout.
+
+struct PointLightGPU
+{
+    glm::vec4 positionRadius; ///< xyz = world position, w = influence radius
+    glm::vec4 colorIntensity; ///< xyz = linear-RGB colour,  w = intensity
+};
+static_assert(sizeof(PointLightGPU) == 32);
+
+struct SpotLightGPU
+{
+    glm::vec4 positionRadius; ///< xyz = world position,       w = influence radius
+    glm::vec4 directionInner; ///< xyz = direction (unit vec),  w = cos(innerAngle)
+    glm::vec4 colorIntensity; ///< xyz = linear-RGB colour,     w = intensity
+    float     outerCutoff;    ///< cos(outerAngle)
+    float     _pad[3]{};
+};
+static_assert(sizeof(SpotLightGPU) == 64);
+
+struct DirLightGPU
+{
+    glm::vec4 directionIntensity; ///< xyz = direction toward light (unit vec), w = intensity
+    glm::vec4 colorPad;           ///< xyz = linear-RGB colour, w = unused
+};
+static_assert(sizeof(DirLightGPU) == 32);
+
+// ---------------------------------------------------------------------------
+
+/// @brief Manages all SSBOs and compute shaders for clustered forward lighting.
+class ClusterGrid
+{
+  public:
+    // ----- Grid constants --------------------------------------------------
+    static constexpr unsigned int kNumX        = 16u;
+    static constexpr unsigned int kNumY        = 9u;
+    static constexpr unsigned int kNumZ        = 24u;
+    static constexpr unsigned int kNumClusters = kNumX * kNumY * kNumZ; // 3 456
+
+    /// Maximum light indices stored in the global list, per light type.
+    /// Point indices occupy [0, kMaxLightIndices) and spot indices occupy
+    /// [kMaxLightIndices, 2 * kMaxLightIndices) in the same buffer.
+    static constexpr unsigned int kMaxLightIndices = 65536u;
+
+    // ----- SSBO binding points (shared with all shaders) ------------------
+    static constexpr unsigned int kBindingClusterAABB = 0u;
+    static constexpr unsigned int kBindingPointLights = 1u;
+    static constexpr unsigned int kBindingSpotLights  = 2u;
+    static constexpr unsigned int kBindingDirLights   = 3u;
+    static constexpr unsigned int kBindingLightIndex  = 4u;
+    static constexpr unsigned int kBindingLightGrid   = 5u;
+    static constexpr unsigned int kBindingGlobalCount = 6u;
+
+    ClusterGrid() = default;
+    ~ClusterGrid();
+
+    ClusterGrid(const ClusterGrid &) = delete;
+    ClusterGrid &operator=(const ClusterGrid &) = delete;
+
+    ClusterGrid(ClusterGrid &&) noexcept;
+    ClusterGrid &operator=(ClusterGrid &&) noexcept;
+
+    /// @brief Load compute shaders and allocate all SSBOs.
+    /// @return false if either compute shader failed to compile.
+    bool Initialize();
+
+    /// @brief Rebuild cluster AABBs. Call once on init and again on viewport/projection change.
+    void BuildClusters(int width, int height, float nearZ, float farZ, const glm::mat4 &invProjection);
+
+    /// @brief Upload lights to SSBOs and run the culling compute pass.
+    ///        All SSBOs remain bound for subsequent DrawScene calls.
+    void CullLights(const std::vector<PointLightGPU> &pointLights,
+                    const std::vector<SpotLightGPU>  &spotLights,
+                    const std::vector<DirLightGPU>   &dirLights,
+                    const glm::mat4                  &view);
+
+    float NearZ() const { return _nearZ; }
+    float FarZ()  const { return _farZ; }
+    int   Width() const { return _width; }
+    int   Height() const { return _height; }
+
+  private:
+    void AllocateBuffers();
+    void BindAll() const;
+    void Destroy() noexcept;
+
+    ComputeShader _buildShader;
+    ComputeShader _cullShader;
+
+    unsigned int _clusterAABBBuffer = 0u;
+    unsigned int _pointLightBuffer  = 0u;
+    unsigned int _spotLightBuffer   = 0u;
+    unsigned int _dirLightBuffer    = 0u;
+    unsigned int _lightIndexBuffer  = 0u;
+    unsigned int _lightGridBuffer   = 0u;
+    unsigned int _globalCountBuffer = 0u;
+
+    float _nearZ  = 0.1f;
+    float _farZ   = 200.f;
+    int   _width  = 0;
+    int   _height = 0;
+};
+
+} // namespace Assisi::Render

--- a/modules/Render/include/Assisi/Render/ComputeShader.hpp
+++ b/modules/Render/include/Assisi/Render/ComputeShader.hpp
@@ -1,0 +1,152 @@
+/* Copyright (c) 2025 Francisco Vivas Puerto (aka "DaFrancc"). */
+#pragma once
+
+/// @file ComputeShader.hpp
+/// @brief Single-stage compute shader wrapper with asset-system integration.
+///
+/// `ComputeShader` compiles a compute stage sourced through `AssetSystem`,
+/// links it into an OpenGL program, and exposes typed uniform setters.
+/// Move-only; copying is disabled.
+
+#include <glad/glad.h>
+
+#include <Assisi/Core/AssetSystem.hpp>
+#include <Assisi/Core/Logger.hpp>
+#include <Assisi/Math/GLM.hpp>
+
+#include <expected>
+#include <string>
+#include <string_view>
+
+namespace Assisi::Render
+{
+
+/// @brief Owns a linked OpenGL compute shader program.
+class ComputeShader
+{
+  public:
+    ComputeShader() = default;
+
+    /// @brief Builds a compute program from a virtual asset path.
+    explicit ComputeShader(std::string_view computeVPath)
+    {
+        (void)LoadFromAssets(computeVPath);
+    }
+
+    /// @brief (Re)loads, compiles, and links the compute shader from a virtual asset path.
+    std::expected<void, Assisi::Core::AssetError> LoadFromAssets(std::string_view computeVPath) noexcept
+    {
+        Destroy();
+
+        auto src = Assisi::Core::AssetSystem::ReadText(computeVPath);
+        if (!src)
+            return std::unexpected(src.error());
+
+        const char *csrc = src->c_str();
+        const unsigned int cs = glCreateShader(GL_COMPUTE_SHADER);
+        glShaderSource(cs, 1, &csrc, nullptr);
+        glCompileShader(cs);
+
+        int ok = 0;
+        glGetShaderiv(cs, GL_COMPILE_STATUS, &ok);
+        if (!ok)
+        {
+            char buf[1024];
+            glGetShaderInfoLog(cs, 1024, nullptr, buf);
+            Assisi::Core::Log::Error("ComputeShader: Compilation failed for '{}'\n{}", computeVPath, buf);
+            glDeleteShader(cs);
+            return {};
+        }
+
+        _program = glCreateProgram();
+        glAttachShader(_program, cs);
+        glLinkProgram(_program);
+        glDeleteShader(cs);
+
+        glGetProgramiv(_program, GL_LINK_STATUS, &ok);
+        if (!ok)
+        {
+            char buf[1024];
+            glGetProgramInfoLog(_program, 1024, nullptr, buf);
+            Assisi::Core::Log::Error("ComputeShader: Linking failed for '{}'\n{}", computeVPath, buf);
+            Destroy();
+        }
+
+        return {};
+    }
+
+    void         Use()     const { glUseProgram(_program); }
+    bool         IsValid() const { return _program != 0u; }
+    unsigned int ProgramIdentifier() const { return _program; }
+
+    /// @brief Dispatches the compute shader with the given workgroup counts.
+    void Dispatch(unsigned int x, unsigned int y, unsigned int z) const
+    {
+        glUseProgram(_program);
+        glDispatchCompute(x, y, z);
+    }
+
+    /// @name Uniform setters (program must be bound via Use() first, or call Dispatch which binds it)
+    ///@{
+    void SetInt(const std::string &name, int v) const
+    {
+        glUniform1i(glGetUniformLocation(_program, name.c_str()), v);
+    }
+
+    void SetUInt(const std::string &name, unsigned int v) const
+    {
+        glUniform1ui(glGetUniformLocation(_program, name.c_str()), v);
+    }
+
+    void SetFloat(const std::string &name, float v) const
+    {
+        glUniform1f(glGetUniformLocation(_program, name.c_str()), v);
+    }
+
+    void SetVec2(const std::string &name, float x, float y) const
+    {
+        glUniform2f(glGetUniformLocation(_program, name.c_str()), x, y);
+    }
+
+    void SetUVec3(const std::string &name, unsigned int x, unsigned int y, unsigned int z) const
+    {
+        glUniform3ui(glGetUniformLocation(_program, name.c_str()), x, y, z);
+    }
+
+    void SetMat4(const std::string &name, const glm::mat4 &v) const
+    {
+        glUniformMatrix4fv(glGetUniformLocation(_program, name.c_str()), 1, GL_FALSE, &v[0][0]);
+    }
+    ///@}
+
+    ~ComputeShader() { Destroy(); }
+
+    ComputeShader(const ComputeShader &) = delete;
+    ComputeShader &operator=(const ComputeShader &) = delete;
+
+    ComputeShader(ComputeShader &&o) noexcept { *this = std::move(o); }
+    ComputeShader &operator=(ComputeShader &&o) noexcept
+    {
+        if (this != &o)
+        {
+            Destroy();
+            _program   = o._program;
+            o._program = 0u;
+        }
+        return *this;
+    }
+
+  private:
+    void Destroy() noexcept
+    {
+        if (_program != 0u)
+        {
+            glDeleteProgram(_program);
+            _program = 0u;
+        }
+    }
+
+    unsigned int _program = 0u;
+};
+
+} // namespace Assisi::Render

--- a/modules/Render/include/Assisi/Render/Shader.hpp
+++ b/modules/Render/include/Assisi/Render/Shader.hpp
@@ -167,6 +167,16 @@ class Shader
         glUniformMatrix2fv(glGetUniformLocation(_programIdentifier, uniformName.c_str()), 1, GL_FALSE, &value[0][0]);
     }
 
+    void SetUInt(const std::string &uniformName, unsigned int value) const
+    {
+        glUniform1ui(glGetUniformLocation(_programIdentifier, uniformName.c_str()), value);
+    }
+
+    void SetUVec3(const std::string &uniformName, unsigned int x, unsigned int y, unsigned int z) const
+    {
+        glUniform3ui(glGetUniformLocation(_programIdentifier, uniformName.c_str()), x, y, z);
+    }
+
     void SetMat3(const std::string &uniformName, const glm::mat3 &value) const
     {
         glUniformMatrix3fv(glGetUniformLocation(_programIdentifier, uniformName.c_str()), 1, GL_FALSE, &value[0][0]);

--- a/modules/Render/src/ClusterGrid.cpp
+++ b/modules/Render/src/ClusterGrid.cpp
@@ -1,0 +1,192 @@
+/* Copyright (c) 2025 Francisco Vivas Puerto (aka "DaFrancc"). */
+
+#include <glad/glad.h>
+
+#include <Assisi/Core/Logger.hpp>
+#include <Assisi/Render/ClusterGrid.hpp>
+
+#include <algorithm>
+#include <cstring>
+
+namespace Assisi::Render
+{
+
+// ---- Lifetime --------------------------------------------------------------
+
+ClusterGrid::~ClusterGrid()
+{
+    Destroy();
+}
+
+ClusterGrid::ClusterGrid(ClusterGrid &&o) noexcept
+{
+    *this = std::move(o);
+}
+
+ClusterGrid &ClusterGrid::operator=(ClusterGrid &&o) noexcept
+{
+    if (this != &o)
+    {
+        Destroy();
+        _buildShader       = std::move(o._buildShader);
+        _cullShader        = std::move(o._cullShader);
+        _clusterAABBBuffer = o._clusterAABBBuffer; o._clusterAABBBuffer = 0u;
+        _pointLightBuffer  = o._pointLightBuffer;  o._pointLightBuffer  = 0u;
+        _spotLightBuffer   = o._spotLightBuffer;   o._spotLightBuffer   = 0u;
+        _dirLightBuffer    = o._dirLightBuffer;    o._dirLightBuffer    = 0u;
+        _lightIndexBuffer  = o._lightIndexBuffer;  o._lightIndexBuffer  = 0u;
+        _lightGridBuffer   = o._lightGridBuffer;   o._lightGridBuffer   = 0u;
+        _globalCountBuffer = o._globalCountBuffer; o._globalCountBuffer = 0u;
+        _nearZ  = o._nearZ;
+        _farZ   = o._farZ;
+        _width  = o._width;
+        _height = o._height;
+    }
+    return *this;
+}
+
+// ---- Initialize / destroy --------------------------------------------------
+
+bool ClusterGrid::Initialize()
+{
+    _buildShader = ComputeShader("shaders/cluster_build.comp");
+    if (!_buildShader.IsValid())
+    {
+        Assisi::Core::Log::Error("ClusterGrid: failed to compile cluster_build.comp");
+        return false;
+    }
+
+    _cullShader = ComputeShader("shaders/cluster_cull.comp");
+    if (!_cullShader.IsValid())
+    {
+        Assisi::Core::Log::Error("ClusterGrid: failed to compile cluster_cull.comp");
+        return false;
+    }
+
+    AllocateBuffers();
+    return true;
+}
+
+void ClusterGrid::AllocateBuffers()
+{
+    auto alloc = [](unsigned int &buf, GLsizeiptr bytes)
+    {
+        if (buf)
+            glDeleteBuffers(1, &buf);
+        glCreateBuffers(1, &buf);
+        glNamedBufferData(buf, bytes, nullptr, GL_DYNAMIC_DRAW);
+    };
+
+    // Cluster AABB buffer: 2 × vec4 (32 bytes) per cluster
+    alloc(_clusterAABBBuffer, static_cast<GLsizeiptr>(kNumClusters * 32u));
+
+    // Light index list: 2 × kMaxLightIndices uint32s (point first, then spot)
+    alloc(_lightIndexBuffer, static_cast<GLsizeiptr>(kMaxLightIndices * 2u * sizeof(unsigned int)));
+
+    // Light grid: 4 × uint32 (16 bytes) per cluster
+    alloc(_lightGridBuffer, static_cast<GLsizeiptr>(kNumClusters * 16u));
+
+    // Atomic counters (2 × uint32)
+    alloc(_globalCountBuffer, static_cast<GLsizeiptr>(2u * sizeof(unsigned int)));
+
+    // Light data buffers — sized to 1 byte initially; resized on first upload
+    auto allocTiny = [](unsigned int &buf)
+    {
+        if (buf)
+            glDeleteBuffers(1, &buf);
+        glCreateBuffers(1, &buf);
+        glNamedBufferData(buf, 4, nullptr, GL_DYNAMIC_DRAW);
+    };
+    allocTiny(_pointLightBuffer);
+    allocTiny(_spotLightBuffer);
+    allocTiny(_dirLightBuffer);
+}
+
+void ClusterGrid::Destroy() noexcept
+{
+    auto del = [](unsigned int &buf)
+    {
+        if (buf)
+        {
+            glDeleteBuffers(1, &buf);
+            buf = 0u;
+        }
+    };
+    del(_clusterAABBBuffer);
+    del(_pointLightBuffer);
+    del(_spotLightBuffer);
+    del(_dirLightBuffer);
+    del(_lightIndexBuffer);
+    del(_lightGridBuffer);
+    del(_globalCountBuffer);
+}
+
+// ---- BuildClusters ---------------------------------------------------------
+
+void ClusterGrid::BuildClusters(int width, int height, float nearZ, float farZ,
+                                const glm::mat4 &invProjection)
+{
+    _nearZ  = nearZ;
+    _farZ   = farZ;
+    _width  = width;
+    _height = height;
+
+    glBindBufferBase(GL_SHADER_STORAGE_BUFFER, kBindingClusterAABB, _clusterAABBBuffer);
+
+    _buildShader.Use();
+    _buildShader.SetUVec3("uGridDim",  kNumX, kNumY, kNumZ);
+    _buildShader.SetVec2("uScreenSize", static_cast<float>(width), static_cast<float>(height));
+    _buildShader.SetFloat("uNearZ", nearZ);
+    _buildShader.SetFloat("uFarZ",  farZ);
+    _buildShader.SetMat4("uInvProjection", invProjection);
+
+    glDispatchCompute(kNumX, kNumY, kNumZ);
+    glMemoryBarrier(GL_SHADER_STORAGE_BARRIER_BIT);
+}
+
+// ---- CullLights ------------------------------------------------------------
+
+void ClusterGrid::BindAll() const
+{
+    glBindBufferBase(GL_SHADER_STORAGE_BUFFER, kBindingClusterAABB,  _clusterAABBBuffer);
+    glBindBufferBase(GL_SHADER_STORAGE_BUFFER, kBindingPointLights,  _pointLightBuffer);
+    glBindBufferBase(GL_SHADER_STORAGE_BUFFER, kBindingSpotLights,   _spotLightBuffer);
+    glBindBufferBase(GL_SHADER_STORAGE_BUFFER, kBindingDirLights,    _dirLightBuffer);
+    glBindBufferBase(GL_SHADER_STORAGE_BUFFER, kBindingLightIndex,   _lightIndexBuffer);
+    glBindBufferBase(GL_SHADER_STORAGE_BUFFER, kBindingLightGrid,    _lightGridBuffer);
+    glBindBufferBase(GL_SHADER_STORAGE_BUFFER, kBindingGlobalCount,  _globalCountBuffer);
+}
+
+void ClusterGrid::CullLights(const std::vector<PointLightGPU> &pointLights,
+                             const std::vector<SpotLightGPU>  &spotLights,
+                             const std::vector<DirLightGPU>   &dirLights,
+                             const glm::mat4                  &view)
+{
+    // Upload light data (glNamedBufferData reallocates if size changed)
+    auto upload = [](unsigned int buf, const void *data, size_t bytes)
+    {
+        glNamedBufferData(buf, static_cast<GLsizeiptr>(std::max(bytes, size_t{4})), data, GL_DYNAMIC_DRAW);
+    };
+    upload(_pointLightBuffer, pointLights.data(), pointLights.size() * sizeof(PointLightGPU));
+    upload(_spotLightBuffer,  spotLights.data(),  spotLights.size()  * sizeof(SpotLightGPU));
+    upload(_dirLightBuffer,   dirLights.data(),   dirLights.size()   * sizeof(DirLightGPU));
+
+    // Reset global atomic counters to zero
+    const unsigned int zeros[2] = {0u, 0u};
+    glNamedBufferSubData(_globalCountBuffer, 0, sizeof(zeros), zeros);
+
+    // Bind all SSBOs (they stay bound for the subsequent DrawScene call)
+    BindAll();
+
+    // Dispatch culling pass
+    _cullShader.Use();
+    _cullShader.SetUVec3("uGridDim", kNumX, kNumY, kNumZ);
+    _cullShader.SetUInt("uPointLightCount", static_cast<unsigned int>(pointLights.size()));
+    _cullShader.SetUInt("uSpotLightCount",  static_cast<unsigned int>(spotLights.size()));
+    _cullShader.SetMat4("uView", view);
+
+    glDispatchCompute(kNumX, kNumY, kNumZ);
+    glMemoryBarrier(GL_SHADER_STORAGE_BARRIER_BIT);
+}
+
+} // namespace Assisi::Render

--- a/modules/Runtime/CMakeLists.txt
+++ b/modules/Runtime/CMakeLists.txt
@@ -5,10 +5,13 @@ target_sources(Assisi-Runtime
   PUBLIC
     "include/Assisi/Runtime/Camera.hpp"
     "include/Assisi/Runtime/Components.hpp"
+    "include/Assisi/Runtime/LightComponents.hpp"
+    "include/Assisi/Runtime/LightingSystem.hpp"
     "include/Assisi/Runtime/Renderer.hpp"
     "include/Assisi/Runtime/Transform.hpp"
   PRIVATE
     "src/Camera.cpp"
+    "src/LightingSystem.cpp"
     "src/Renderer.cpp"
 )
 

--- a/modules/Runtime/include/Assisi/Runtime/LightComponents.hpp
+++ b/modules/Runtime/include/Assisi/Runtime/LightComponents.hpp
@@ -1,0 +1,57 @@
+/* Copyright (c) 2025 Francisco Vivas Puerto (aka "DaFrancc"). */
+#pragma once
+
+/// @file LightComponents.hpp
+/// @brief ECS component types for the three basic dynamic light types.
+///
+/// All three types are trivially copyable (plain data, no pointers).
+///
+/// Placement:
+///   - DirectionalLightComponent  — direction is stored directly on the component;
+///     no TransformComponent is needed (it has no world position).
+///   - PointLightComponent        — requires a TransformComponent for world position.
+///   - SpotLightComponent         — requires a TransformComponent for world position;
+///     direction is stored on the component.
+
+#include <Assisi/Math/GLM.hpp>
+
+namespace Assisi::Runtime
+{
+
+/// @brief Infinite-distance directional light (sun / moon).
+///
+/// No position, no falloff.  Multiple directional lights are supported.
+struct DirectionalLightComponent
+{
+    glm::vec3 direction{0.f, -1.f, 0.f}; ///< World-space direction toward the light (unit vector).
+    glm::vec3 color{1.f, 1.f, 1.f};      ///< Linear-RGB colour.
+    float     intensity = 1.f;
+};
+
+/// @brief Omnidirectional point light with distance falloff.
+///
+/// Requires TransformComponent for world position.
+/// Uses windowed inverse-square attenuation: zero contribution beyond `radius`.
+struct PointLightComponent
+{
+    glm::vec3 color{1.f, 1.f, 1.f}; ///< Linear-RGB colour.
+    float     intensity = 1.f;
+    float     radius    = 10.f;      ///< Maximum influence range in world units.
+};
+
+/// @brief Cone-restricted point light (flashlight / stage spotlight).
+///
+/// Requires TransformComponent for world position.
+/// Intensity falls off with distance (same attenuation as PointLight) and
+/// is smoothly masked outside the cone between innerAngle and outerAngle.
+struct SpotLightComponent
+{
+    glm::vec3 direction{0.f, -1.f, 0.f}; ///< World-space direction (unit vector).
+    glm::vec3 color{1.f, 1.f, 1.f};      ///< Linear-RGB colour.
+    float     intensity   = 1.f;
+    float     radius      = 10.f;         ///< Maximum influence range in world units.
+    float     innerAngle  = 15.f;         ///< Half-angle of the full-brightness cone (degrees).
+    float     outerAngle  = 30.f;         ///< Half-angle of the cutoff cone (degrees).
+};
+
+} // namespace Assisi::Runtime

--- a/modules/Runtime/include/Assisi/Runtime/LightingSystem.hpp
+++ b/modules/Runtime/include/Assisi/Runtime/LightingSystem.hpp
@@ -1,0 +1,60 @@
+/* Copyright (c) 2025 Francisco Vivas Puerto (aka "DaFrancc"). */
+#pragma once
+
+/// @file LightingSystem.hpp
+/// @brief Bridges the ECS scene to the clustered forward lighting pipeline.
+///
+/// LightingSystem queries light components from the scene each frame,
+/// uploads them to the GPU, and runs the cluster culling compute pass.
+///
+/// Usage:
+///   1. Call Initialize() once after the OpenGL context is ready.
+///   2. Call Resize() whenever the viewport or projection changes.
+///   3. Call Update() every frame before DrawScene().
+///   4. After Update(), set `uDirLightCount` on the mesh shader using DirLightCount().
+
+#include <Assisi/ECS/Scene.hpp>
+#include <Assisi/Math/GLM.hpp>
+#include <Assisi/Render/ClusterGrid.hpp>
+#include <Assisi/Render/Shader.hpp>
+
+#include <cstdint>
+
+namespace Assisi::Runtime
+{
+
+class LightingSystem
+{
+  public:
+    LightingSystem() = default;
+
+    /// @brief Load compute shaders, allocate SSBOs, and build initial cluster AABBs.
+    /// @param width,height  Framebuffer size in pixels.
+    /// @param nearZ,farZ    Near/far clip distances matching the projection matrix.
+    /// @param projection    The camera projection matrix.
+    /// @return false if compute shaders failed to compile.
+    bool Initialize(int width, int height, float nearZ, float farZ, const glm::mat4 &projection);
+
+    /// @brief Rebuild cluster AABBs after a viewport or projection change.
+    void Resize(int width, int height, float nearZ, float farZ, const glm::mat4 &projection);
+
+    /// @brief Collect lights from the scene, upload to GPU, and run the cull pass.
+    ///        Binds all SSBOs to their fixed binding points for the mesh shader.
+    void Update(Assisi::ECS::Scene &scene, const glm::mat4 &view);
+
+    /// @brief Set the static cluster uniforms on the mesh shader.
+    ///        Call once after Initialize() and again after every Resize().
+    void SetupMeshShader(Assisi::Render::Shader &shader) const;
+
+    /// @brief Number of directional lights found in the last Update() call.
+    ///        Set as `uDirLightCount` on the mesh shader each frame.
+    uint32_t DirLightCount() const { return _dirLightCount; }
+
+    const Assisi::Render::ClusterGrid &Grid() const { return _grid; }
+
+  private:
+    Assisi::Render::ClusterGrid _grid;
+    uint32_t                    _dirLightCount = 0u;
+};
+
+} // namespace Assisi::Runtime

--- a/modules/Runtime/src/LightingSystem.cpp
+++ b/modules/Runtime/src/LightingSystem.cpp
@@ -1,0 +1,76 @@
+/* Copyright (c) 2025 Francisco Vivas Puerto (aka "DaFrancc"). */
+
+#include <Assisi/Runtime/LightingSystem.hpp>
+#include <Assisi/Runtime/LightComponents.hpp>
+#include <Assisi/Runtime/Components.hpp>
+
+namespace Assisi::Runtime
+{
+
+bool LightingSystem::Initialize(int width, int height, float nearZ, float farZ,
+                                const glm::mat4 &projection)
+{
+    if (!_grid.Initialize())
+        return false;
+
+    _grid.BuildClusters(width, height, nearZ, farZ, glm::inverse(projection));
+    return true;
+}
+
+void LightingSystem::Resize(int width, int height, float nearZ, float farZ,
+                            const glm::mat4 &projection)
+{
+    _grid.BuildClusters(width, height, nearZ, farZ, glm::inverse(projection));
+}
+
+void LightingSystem::Update(Assisi::ECS::Scene &scene, const glm::mat4 &view)
+{
+    std::vector<Assisi::Render::PointLightGPU> pointLights;
+    std::vector<Assisi::Render::SpotLightGPU>  spotLights;
+    std::vector<Assisi::Render::DirLightGPU>   dirLights;
+
+    for (auto [entity, transform, light] : scene.Query<TransformComponent, PointLightComponent>())
+    {
+        pointLights.push_back({
+            .positionRadius = {transform.position, light.radius},
+            .colorIntensity = {light.color, light.intensity},
+        });
+    }
+
+    for (auto [entity, transform, light] : scene.Query<TransformComponent, SpotLightComponent>())
+    {
+        const float innerCos = glm::cos(glm::radians(light.innerAngle));
+        const float outerCos = glm::cos(glm::radians(light.outerAngle));
+        spotLights.push_back({
+            .positionRadius = {transform.position, light.radius},
+            .directionInner = {glm::normalize(light.direction), innerCos},
+            .colorIntensity = {light.color, light.intensity},
+            .outerCutoff    = outerCos,
+        });
+    }
+
+    for (auto [entity, light] : scene.Query<DirectionalLightComponent>())
+    {
+        dirLights.push_back({
+            .directionIntensity = {glm::normalize(light.direction), light.intensity},
+            .colorPad           = {light.color, 0.f},
+        });
+    }
+
+    _dirLightCount = static_cast<uint32_t>(dirLights.size());
+    _grid.CullLights(pointLights, spotLights, dirLights, view);
+}
+
+void LightingSystem::SetupMeshShader(Assisi::Render::Shader &shader) const
+{
+    shader.Use();
+    shader.SetUVec3("uGridDim",    Assisi::Render::ClusterGrid::kNumX,
+                                   Assisi::Render::ClusterGrid::kNumY,
+                                   Assisi::Render::ClusterGrid::kNumZ);
+    shader.SetVec2("uScreenSize",  static_cast<float>(_grid.Width()),
+                                   static_cast<float>(_grid.Height()));
+    shader.SetFloat("uNearZ",  _grid.NearZ());
+    shader.SetFloat("uFarZ",   _grid.FarZ());
+}
+
+} // namespace Assisi::Runtime


### PR DESCRIPTION
…l lights

Replaces the single hardcoded directional light uniform with a full clustered forward pipeline. The view frustum is subdivided into a 16x9x24 grid; a compute pass assigns lights to clusters each frame so fragment shaders only iterate lights that touch their cluster.

- ComputeShader: single-stage compute shader wrapper
- ClusterGrid: manages cluster AABB SSBOs, light data SSBOs, and both compute passes (cluster_build.comp, cluster_cull.comp)
- LightComponents: DirectionalLightComponent, PointLightComponent, SpotLightComponent ECS components
- LightingSystem: queries light components from the scene, uploads to GPU, runs cull pass; exposes SetupMeshShader for static cluster uniforms
- mesh.frag/vert: SSBO-based light lookup with Cook-Torrance BRDF per light type; windowed inverse-square attenuation for point/spot
- Shader: add SetUInt and SetUVec3
- conanfile.txt: bump glad to OpenGL 4.6 (required for compute shaders, SSBOs, and DSA buffer functions)
- Sandbox: sun entity, three PBR test cubes, three coloured point lights