### PR TITLE
Add .alvl level file format with reflection-driven serialization and …

### DIFF
--- a/apps/sandbox/CMakeLists.txt
+++ b/apps/sandbox/CMakeLists.txt
@@ -14,6 +14,8 @@ target_link_libraries(Assisi-Sandbox
     OpenGL::GL
 )
 
+assisi_link_reflections(Assisi-Sandbox)
+
 add_custom_command(TARGET Assisi-Sandbox POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E copy_directory
         "${CMAKE_SOURCE_DIR}/assets"

--- a/apps/sandbox/src/main.cpp
+++ b/apps/sandbox/src/main.cpp
@@ -1,8 +1,9 @@
 /// @file main.cpp
-/// @brief Assisi Sandbox — physics demo built on the Application layer.
+/// @brief Assisi Sandbox — level viewer built on the Application layer.
 
 #include <Assisi/App/Application.hpp>
 
+#include <Assisi/Core/AssetSystem.hpp>
 #include <Assisi/Core/Logger.hpp>
 #include <Assisi/ECS/SceneRegistry.hpp>
 #include <Assisi/Physics/PhysicsComponents.hpp>
@@ -10,19 +11,19 @@
 #include <Assisi/Render/DefaultMeshes.hpp>
 #include <Assisi/Render/OpenGL/MeshBuffer.hpp>
 #include <Assisi/Render/Shader.hpp>
-
-#include <glad/glad.h>
 #include <Assisi/Runtime/Camera.hpp>
 #include <Assisi/Runtime/Components.hpp>
-#include <Assisi/Runtime/LightComponents.hpp>
 #include <Assisi/Runtime/LightingSystem.hpp>
 #include <Assisi/Runtime/Renderer.hpp>
+#include <Assisi/Runtime/SceneSerializer.hpp>
 #include <Assisi/Window/Key.hpp>
 
 #include <imgui.h>
 
+#include <algorithm>
 #include <cstdlib>
-#include <tuple>
+#include <filesystem>
+#include <string>
 
 // ---------------------------------------------------------------------------
 // SandboxApp
@@ -36,13 +37,16 @@ class SandboxApp : public Assisi::App::Application
     void OnUpdate(float dt);
     void OnRender();
     void OnImGui();
-    void OnShutdown() override;
     void OnResize(int width, int height) override;
 
   private:
-    Assisi::ECS::SceneRegistry    _scenes;
-    Assisi::ECS::Scene           *_scene = nullptr;
-    Assisi::Physics::PhysicsWorld _physics;
+    void ScanLevels();
+    void LoadLevel(const std::string &name);
+    void SaveLevel(const std::string &name);
+
+    Assisi::ECS::SceneRegistry         _scenes;
+    Assisi::ECS::Scene                *_scene = nullptr;
+    Assisi::Physics::PhysicsWorld      _physics;
 
     Assisi::Render::OpenGL::MeshBuffer _cubeMesh;
     Assisi::Render::Shader             _shader;
@@ -54,33 +58,22 @@ class SandboxApp : public Assisi::App::Application
     static constexpr float kFarZ  = 200.f;
 
     // Camera control state
-    float _yaw         = -116.6f; // initialised in OnStart from camera direction
-    float _pitch       =  -24.1f;
-    float _fovDegrees  =   60.f;
+    float _yaw        = -116.6f;
+    float _pitch      =  -24.1f;
+    float _fovDegrees =   60.f;
 
     static constexpr float kMoveSpeed        = 8.f;   // units/s
     static constexpr float kMouseSensitivity = 0.1f;  // degrees/pixel
 
-    std::vector<unsigned int>           _testTextures; // owned by sandbox, deleted in OnShutdown
-
-    Assisi::Physics::RigidBodyComponent _cubeRb{};
-    glm::quat                           _cornerRot{1.f, 0.f, 0.f, 0.f};
-    glm::vec3                           _spawnPos{0.f, 6.f, 0.f};
-    int                                 _spawnCount = 0;
+    std::vector<std::string> _levelFiles;
+    int                      _selectedLevel = 0;
+    char                     _saveAsName[128] = {};
 };
 
 // ---------------------------------------------------------------------------
 
 void SandboxApp::OnStart()
 {
-    // Logger examples
-    // Assisi::Core::Log::Trace("Trace: verbose internal detail, {} items", 3);
-    // Assisi::Core::Log::Debug("Debug: useful during development");
-    // Assisi::Core::Log::Info("Info:  general status messages");
-    // Assisi::Core::Log::Warn("Warn:  something unexpected but recoverable");
-    // Assisi::Core::Log::Error("Error: something failed");
-    // Assisi::Core::Log::Fatal("Fatal: unrecoverable, shutting down");
-
     _scene = _scenes.Create("Main").value();
 
     _cubeMesh = Assisi::Render::OpenGL::MeshBuffer(Assisi::Render::CreateUnitCubeMesh());
@@ -95,7 +88,7 @@ void SandboxApp::OnStart()
 
     _camera = Assisi::Runtime::Camera({5.f, 5.f, 10.f}, {0.f, 0.f, 0.f});
 
-    // Lighting system — must be initialised after the OpenGL context is ready
+    // Lighting system — must be initialised after the OpenGL context is ready.
     {
         const auto size = GetWindow().GetFramebufferSize();
         _projection     = MakeProjection(_fovDegrees, kNearZ, kFarZ);
@@ -113,133 +106,7 @@ void SandboxApp::OnStart()
     _pitch = glm::degrees(glm::asin(forward.y));
     _yaw   = glm::degrees(glm::atan(forward.z, forward.x));
 
-    // Directional light (sun)
-    {
-        Assisi::ECS::Entity sun = _scene->Create();
-        std::ignore = _scene->Add<Assisi::Runtime::DirectionalLightComponent>(
-            sun, {.direction = {-0.4f, -1.0f, -0.5f}, .color = {1.f, 1.f, 1.f}, .intensity = 0.5f});
-    }
-
-    // Floor — static box
-    {
-        Assisi::ECS::Entity floor = _scene->Create();
-        std::ignore = _scene->Add<Assisi::Runtime::TransformComponent>(
-            floor, {.position = {0.f, -0.25f, 0.f}, .rotation = {1.f, 0.f, 0.f, 0.f}, .scale = {10.f, 0.5f, 10.f}});
-        std::ignore = _scene->Add<Assisi::Runtime::MeshRendererComponent>(floor, {.mesh = &_cubeMesh, .albedoTextureId = 0u});
-        std::ignore = _scene->Add<Assisi::Physics::RigidBodyComponent>(
-            floor, _physics.AddBox({0.f, -0.25f, 0.f}, {1.f, 0.f, 0.f, 0.f}, {5.f, 0.25f, 5.f},
-                                   Assisi::Physics::BodyMotion::Static));
-    }
-
-    // Dynamic cube — tilted to land on a corner
-    _cornerRot = glm::normalize(
-        glm::angleAxis(glm::radians(45.f), glm::vec3(0.f, 0.f, 1.f)) *
-        glm::angleAxis(glm::radians(45.f), glm::vec3(1.f, 0.f, 0.f)));
-    {
-        Assisi::ECS::Entity cube = _scene->Create();
-        std::ignore = _scene->Add<Assisi::Runtime::TransformComponent>(
-            cube, {.position = _spawnPos, .rotation = _cornerRot, .scale = {1.f, 1.f, 1.f}});
-        std::ignore = _scene->Add<Assisi::Runtime::MeshRendererComponent>(cube, {.mesh = &_cubeMesh, .albedoTextureId = 0u});
-        _cubeRb = _physics.AddBox(_spawnPos, _cornerRot, {0.5f, 0.5f, 0.5f}, Assisi::Physics::BodyMotion::Dynamic);
-        std::ignore = _scene->Add<Assisi::Physics::RigidBodyComponent>(cube, _cubeRb);
-    }
-
-    // Helper: create a 1×1 sRGB texture for a given colour / value
-    auto makeTex = [&](uint8_t r, uint8_t g, uint8_t b) -> unsigned int
-    {
-        unsigned int id = 0;
-        glGenTextures(1, &id);
-        glBindTexture(GL_TEXTURE_2D, id);
-        const uint8_t px[4] = {r, g, b, 255};
-        glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, 1, 1, 0, GL_RGBA, GL_UNSIGNED_BYTE, px);
-        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
-        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
-        _testTextures.push_back(id);
-        return id;
-    };
-
-    // Albedos
-    const unsigned int texGold  = makeTex(255, 200,  50); // warm gold
-    const unsigned int texRed   = makeTex(200,  35,  35); // saturated red
-    const unsigned int texBlue  = makeTex( 55, 100, 220); // cool blue
-
-    // Roughness values (R channel used; white = 1.0, black = 0.0)
-    const unsigned int roughLow  = makeTex(  8,   8,   8); // ~0.03 — near-mirror
-    const unsigned int roughHigh = makeTex(245, 245, 245); // ~0.96 — very rough
-    const unsigned int roughMed  = makeTex(128, 128, 128); // ~0.50 — semi-rough
-
-    // Metallic values
-    const unsigned int metalFull = makeTex(255, 255, 255); // 1.0 — fully metallic
-    const unsigned int metalNone = makeTex(  0,   0,   0); // 0.0 — dielectric
-    const unsigned int metalMed  = makeTex(128, 128, 128); // 0.5 — partial
-
-    // --- Test cube 1: polished gold metal (high metallic, near-zero roughness) ---
-    {
-        constexpr glm::vec3 pos{-3.f, 0.5f, -2.f};
-        Assisi::ECS::Entity cube = _scene->Create();
-        std::ignore = _scene->Add<Assisi::Runtime::TransformComponent>(cube, {.position = pos});
-        std::ignore = _scene->Add<Assisi::Runtime::MeshRendererComponent>(
-            cube, {.mesh = &_cubeMesh, .albedoTextureId = texGold,
-                   .metallicTextureId = metalFull, .roughnessTextureId = roughLow});
-        std::ignore = _scene->Add<Assisi::Physics::RigidBodyComponent>(
-            cube, _physics.AddBox(pos, {1.f, 0.f, 0.f, 0.f}, {0.5f, 0.5f, 0.5f},
-                                  Assisi::Physics::BodyMotion::Dynamic));
-    }
-
-    // --- Test cube 2: rough red plastic (no metallic, high roughness) ---
-    {
-        constexpr glm::vec3 pos{0.f, 0.5f, -3.f};
-        Assisi::ECS::Entity cube = _scene->Create();
-        std::ignore = _scene->Add<Assisi::Runtime::TransformComponent>(cube, {.position = pos});
-        std::ignore = _scene->Add<Assisi::Runtime::MeshRendererComponent>(
-            cube, {.mesh = &_cubeMesh, .albedoTextureId = texRed,
-                   .metallicTextureId = metalNone, .roughnessTextureId = roughHigh});
-        std::ignore = _scene->Add<Assisi::Physics::RigidBodyComponent>(
-            cube, _physics.AddBox(pos, {1.f, 0.f, 0.f, 0.f}, {0.5f, 0.5f, 0.5f},
-                                  Assisi::Physics::BodyMotion::Dynamic));
-    }
-
-    // --- Test cube 3: semi-rough blue ceramic (partial metallic, medium roughness) ---
-    {
-        constexpr glm::vec3 pos{3.f, 0.5f, -2.f};
-        Assisi::ECS::Entity cube = _scene->Create();
-        std::ignore = _scene->Add<Assisi::Runtime::TransformComponent>(cube, {.position = pos});
-        std::ignore = _scene->Add<Assisi::Runtime::MeshRendererComponent>(
-            cube, {.mesh = &_cubeMesh, .albedoTextureId = texBlue,
-                   .metallicTextureId = metalMed, .roughnessTextureId = roughMed});
-        std::ignore = _scene->Add<Assisi::Physics::RigidBodyComponent>(
-            cube, _physics.AddBox(pos, {1.f, 0.f, 0.f, 0.f}, {0.5f, 0.5f, 0.5f},
-                                  Assisi::Physics::BodyMotion::Dynamic));
-    }
-
-    // --- Point lights ---
-
-    // White — overhead centre
-    {
-        Assisi::ECS::Entity light = _scene->Create();
-        std::ignore = _scene->Add<Assisi::Runtime::TransformComponent>(
-            light, {.position = {0.f, 4.f, -1.f}});
-        std::ignore = _scene->Add<Assisi::Runtime::PointLightComponent>(
-            light, {.color = {1.f, 1.f, 1.f}, .intensity = 150.f, .radius = 30.f});
-    }
-
-    // Blue — left side
-    {
-        Assisi::ECS::Entity light = _scene->Create();
-        std::ignore = _scene->Add<Assisi::Runtime::TransformComponent>(
-            light, {.position = {-5.f, 2.5f, 0.f}});
-        std::ignore = _scene->Add<Assisi::Runtime::PointLightComponent>(
-            light, {.color = {0.2f, 0.4f, 1.f}, .intensity = 200.f, .radius = 30.f});
-    }
-
-    // Red — right side
-    {
-        Assisi::ECS::Entity light = _scene->Create();
-        std::ignore = _scene->Add<Assisi::Runtime::TransformComponent>(
-            light, {.position = {5.f, 2.5f, 0.f}});
-        std::ignore = _scene->Add<Assisi::Runtime::PointLightComponent>(
-            light, {.color = {1.f, 0.1f, 0.1f}, .intensity = 200.f, .radius = 30.f});
-    }
+    ScanLevels();
 }
 
 void SandboxApp::OnResize(int width, int height)
@@ -268,13 +135,9 @@ void SandboxApp::OnUpdate(float dt)
     if (input.IsKeyPressed(Assisi::Window::Key::Escape))
     {
         if (input.IsMouseCaptured())
-        {
             input.SetMouseCaptured(false);
-        }
         else
-        {
             RequestClose();
-        }
     }
 
     if (input.IsMouseCaptured())
@@ -302,9 +165,7 @@ void SandboxApp::OnUpdate(float dt)
 
         glm::vec3 pos = _camera.WorldPosition();
         if (glm::length(move) > 0.f)
-        {
             pos += glm::normalize(move) * (kMoveSpeed * dt);
-        }
 
         _camera.SetWorldPosition(pos);
         _camera.SetLookAtTarget(pos + forward);
@@ -336,58 +197,114 @@ void SandboxApp::OnRender()
 
 void SandboxApp::OnImGui()
 {
-    ImGui::Begin("World");
-
+    // ── Diagnostics ─────────────────────────────────────────────────────────
+    ImGui::Begin("Diagnostics");
     ImGui::Text("FPS: %d", GetFps());
     ImGui::Text("Sleep resolution: %.2f ms", GetSleepResolutionMs());
     ImGui::Separator();
-
-    auto [cubePos, cubeRot] = _physics.GetBodyTransform(_cubeRb);
-    ImGui::SeparatorText("Dynamic Cube");
-    ImGui::Text("Position  %.2f  %.2f  %.2f", static_cast<double>(cubePos.x), static_cast<double>(cubePos.y), static_cast<double>(cubePos.z));
-    if (ImGui::Button("Reset Cube"))
-    {
-        _physics.SetBodyTransform(_cubeRb, _spawnPos, _cornerRot);
-    }
-
-    ImGui::SeparatorText("Physics");
-    glm::vec3 gravity = _physics.GetGravity();
-    if (ImGui::SliderFloat("Gravity Y", &gravity.y, -20.f, 0.f))
-    {
-        _physics.SetGravity(gravity);
-    }
-
-    ImGui::SeparatorText("Spawn");
-    if (ImGui::Button("Spawn Cube"))
-    {
-        const float offsetX = static_cast<float>((_spawnCount % 5) - 2) * 1.5f;
-        const float offsetZ = static_cast<float>((_spawnCount / 5 % 5) - 2) * 1.5f;
-        const glm::vec3 spawnPos = {offsetX, 8.f, offsetZ};
-
-        Assisi::ECS::Entity newCube = _scene->Create();
-        std::ignore = _scene->Add<Assisi::Runtime::TransformComponent>(
-            newCube, {.position = spawnPos, .rotation = _cornerRot, .scale = {1.f, 1.f, 1.f}});
-        std::ignore = _scene->Add<Assisi::Runtime::MeshRendererComponent>(
-            newCube, {.mesh = &_cubeMesh, .albedoTextureId = 0u});
-        const auto newRb = _physics.AddBox(spawnPos, _cornerRot, {0.5f, 0.5f, 0.5f},
-                                           Assisi::Physics::BodyMotion::Dynamic);
-        std::ignore = _scene->Add<Assisi::Physics::RigidBodyComponent>(newCube, newRb);
-        ++_spawnCount;
-    }
-    ImGui::SameLine();
-    ImGui::Text("(%d spawned)", _spawnCount);
-
-    ImGui::SeparatorText("Hint");
     ImGui::TextDisabled("LMB: capture  |  WASD: move  |  Space/Ctrl: up/down");
     ImGui::TextDisabled("Mouse: look  |  Scroll: FOV  |  Esc: release / quit");
+    ImGui::End();
+
+    // ── Level Loader ────────────────────────────────────────────────────────
+    ImGui::Begin("Levels");
+
+    if (ImGui::Button("Refresh"))
+        ScanLevels();
+
+    if (_levelFiles.empty())
+    {
+        ImGui::TextDisabled("No .json files found in assets/levels/");
+    }
+    else
+    {
+        ImGui::SetNextItemWidth(-1.0f);
+        if (ImGui::BeginCombo("##level", _levelFiles[_selectedLevel].c_str()))
+        {
+            for (int i = 0; i < static_cast<int>(_levelFiles.size()); ++i)
+            {
+                const bool selected = (i == _selectedLevel);
+                if (ImGui::Selectable(_levelFiles[i].c_str(), selected))
+                    _selectedLevel = i;
+                if (selected)
+                    ImGui::SetItemDefaultFocus();
+            }
+            ImGui::EndCombo();
+        }
+        const float halfW = (ImGui::GetContentRegionAvail().x - ImGui::GetStyle().ItemSpacing.x) * 0.5f;
+        if (ImGui::Button("Load", ImVec2(halfW, 0.0f)))
+            LoadLevel(_levelFiles[_selectedLevel]);
+        ImGui::SameLine();
+        if (ImGui::Button("Save", ImVec2(-1.0f, 0.0f)))
+            SaveLevel(_levelFiles[_selectedLevel]);
+    }
+
+    ImGui::Separator();
+    ImGui::SetNextItemWidth(-ImGui::CalcTextSize("Save As").x - ImGui::GetStyle().ItemSpacing.x
+                            - ImGui::GetStyle().FramePadding.x * 2.0f);
+    ImGui::InputText("##saveas", _saveAsName, sizeof(_saveAsName));
+    ImGui::SameLine();
+    if (ImGui::Button("Save As") && _saveAsName[0] != '\0')
+    {
+        SaveLevel(_saveAsName);
+        ScanLevels();
+        // Select the newly created file in the dropdown.
+        const std::string newName(_saveAsName);
+        const auto it = std::find(_levelFiles.begin(), _levelFiles.end(), newName);
+        if (it != _levelFiles.end())
+            _selectedLevel = static_cast<int>(std::distance(_levelFiles.begin(), it));
+    }
 
     ImGui::End();
 }
 
-void SandboxApp::OnShutdown()
+void SandboxApp::ScanLevels()
 {
-    if (!_testTextures.empty())
-        glDeleteTextures(static_cast<int>(_testTextures.size()), _testTextures.data());
+    _levelFiles.clear();
+    const auto resolved = Assisi::Core::AssetSystem::Resolve("levels");
+    if (!resolved)
+        return;
+
+    for (const auto &entry : std::filesystem::directory_iterator(*resolved))
+    {
+        if (entry.is_regular_file() && entry.path().extension() == ".alvl")
+            _levelFiles.push_back(entry.path().stem().string());
+    }
+    std::sort(_levelFiles.begin(), _levelFiles.end());
+    _selectedLevel = 0;
+}
+
+void SandboxApp::SaveLevel(const std::string &name)
+{
+    const auto resolved = Assisi::Core::AssetSystem::Resolve("levels/" + name + ".alvl");
+    if (!resolved)
+    {
+        Assisi::Core::Log::Error("SaveLevel: cannot resolve path for '{}'", name);
+        return;
+    }
+    Assisi::Runtime::SceneSerializer::SaveToFile(*_scene, *resolved);
+}
+
+void SandboxApp::LoadLevel(const std::string &name)
+{
+    if (!Assisi::Runtime::SceneSerializer::LoadFromFile(*_scene, "levels/" + name + ".alvl"))
+        return;
+
+    _physics.Clear();
+
+    // MeshRendererComponent::mesh is transient — re-bind after load.
+    for (auto [e, mrc] : _scene->Query<Assisi::Runtime::MeshRendererComponent>())
+        mrc.mesh = &_cubeMesh;
+
+    // Create Jolt bodies for entities that have a RigidBodyDescriptor.
+    for (auto [e, tc, desc] : _scene->Query<Assisi::Runtime::TransformComponent,
+                                             Assisi::Physics::RigidBodyDescriptor>())
+    {
+        const auto motion = desc.isStatic ? Assisi::Physics::BodyMotion::Static
+                                          : Assisi::Physics::BodyMotion::Dynamic;
+        (void)_scene->Add<Assisi::Physics::RigidBodyComponent>(
+            e, _physics.AddBox(tc.position, tc.rotation, desc.halfExtents, motion));
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/assets/levels/Test.alvl
+++ b/assets/levels/Test.alvl
@@ -1,0 +1,126 @@
+{
+  "version": 1,
+  "entities": [
+    {
+      "components": {
+        "DirectionalLightComponent": {
+          "direction": [-0.4, -1.0, -0.5],
+          "color": [1.0, 1.0, 1.0],
+          "intensity": 0.5
+        }
+      }
+    },
+    {
+      "components": {
+        "TransformComponent": {
+          "position": [0.0, -0.25, 0.0],
+          "rotation": [1.0, 0.0, 0.0, 0.0],
+          "scale": [10.0, 0.5, 10.0]
+        },
+        "MeshRendererComponent": {},
+        "RigidBodyDescriptor": {
+          "halfExtents": [5.0, 0.25, 5.0],
+          "isStatic": true
+        }
+      }
+    },
+    {
+      "components": {
+        "TransformComponent": {
+          "position": [0.0, 6.0, 0.0],
+          "rotation": [0.8536, 0.3536, 0.1464, 0.3536],
+          "scale": [1.0, 1.0, 1.0]
+        },
+        "MeshRendererComponent": {},
+        "RigidBodyDescriptor": {
+          "halfExtents": [0.5, 0.5, 0.5],
+          "isStatic": false
+        }
+      }
+    },
+    {
+      "components": {
+        "TransformComponent": {
+          "position": [-3.0, 0.5, -2.0],
+          "rotation": [1.0, 0.0, 0.0, 0.0],
+          "scale": [1.0, 1.0, 1.0]
+        },
+        "MeshRendererComponent": {},
+        "RigidBodyDescriptor": {
+          "halfExtents": [0.5, 0.5, 0.5],
+          "isStatic": false
+        }
+      }
+    },
+    {
+      "components": {
+        "TransformComponent": {
+          "position": [0.0, 0.5, -3.0],
+          "rotation": [1.0, 0.0, 0.0, 0.0],
+          "scale": [1.0, 1.0, 1.0]
+        },
+        "MeshRendererComponent": {},
+        "RigidBodyDescriptor": {
+          "halfExtents": [0.5, 0.5, 0.5],
+          "isStatic": false
+        }
+      }
+    },
+    {
+      "components": {
+        "TransformComponent": {
+          "position": [3.0, 0.5, -2.0],
+          "rotation": [1.0, 0.0, 0.0, 0.0],
+          "scale": [1.0, 1.0, 1.0]
+        },
+        "MeshRendererComponent": {},
+        "RigidBodyDescriptor": {
+          "halfExtents": [0.5, 0.5, 0.5],
+          "isStatic": false
+        }
+      }
+    },
+    {
+      "components": {
+        "TransformComponent": {
+          "position": [0.0, 4.0, -1.0],
+          "rotation": [1.0, 0.0, 0.0, 0.0],
+          "scale": [1.0, 1.0, 1.0]
+        },
+        "PointLightComponent": {
+          "color": [1.0, 1.0, 1.0],
+          "intensity": 150.0,
+          "radius": 30.0
+        }
+      }
+    },
+    {
+      "components": {
+        "TransformComponent": {
+          "position": [-5.0, 2.5, 0.0],
+          "rotation": [1.0, 0.0, 0.0, 0.0],
+          "scale": [1.0, 1.0, 1.0]
+        },
+        "PointLightComponent": {
+          "color": [0.2, 0.4, 1.0],
+          "intensity": 200.0,
+          "radius": 30.0
+        }
+      }
+    },
+    {
+      "components": {
+        "TransformComponent": {
+          "position": [5.0, 2.5, 0.0],
+          "rotation": [1.0, 0.0, 0.0, 0.0],
+          "scale": [1.0, 1.0, 1.0]
+        },
+        "PointLightComponent": {
+          "color": [1.0, 0.1, 0.1],
+          "intensity": 200.0,
+          "radius": 30.0
+        }
+      }
+    }
+  ]
+}

--- a/cmake/AssisiReflect.cmake
+++ b/cmake/AssisiReflect.cmake
@@ -1,5 +1,5 @@
 # AssisiReflect.cmake
-# Provides the assisi_reflect() function for wiring reflectgen into a module's build.
+# Provides the assisi_reflect() and assisi_link_reflections() functions.
 #
 # Usage in a module's CMakeLists.txt:
 #
@@ -11,11 +11,18 @@
 #   )
 #
 # For each listed header that contains ACOMP annotations, a .generated.cpp is
-# produced in ${CMAKE_CURRENT_BINARY_DIR}/generated/ and added as a private
-# source to TARGET.  The #include path inside each generated file is
-# auto-detected from the 'include/' path segment (e.g.
-# modules/Runtime/include/Assisi/Runtime/Components.hpp ->
-# Assisi/Runtime/Components.hpp).
+# produced in ${CMAKE_CURRENT_BINARY_DIR}/generated/.  The sources are compiled
+# into a separate OBJECT library (${TARGET}-Generated) rather than into the
+# module's static library.  This avoids the MSVC linker stripping unreferenced
+# translation units from static libraries, which would silently discard all
+# static-initializer registrations.
+#
+# In the CMakeLists.txt of every final executable that needs reflection:
+#
+#   assisi_link_reflections(Assisi-Sandbox)
+#
+# This adds $<TARGET_OBJECTS:...> for every OBJECT library produced by
+# assisi_reflect() so the registration code is always included in the link.
 
 find_package(Python3 REQUIRED COMPONENTS Interpreter)
 
@@ -60,7 +67,27 @@ function(assisi_reflect)
         list(APPEND _generated_sources "${_out}")
     endforeach()
 
-    target_sources("${_ARG_TARGET}" PRIVATE ${_generated_sources})
-    # Generated files include <Assisi/ECS/Scene.hpp> — make sure ECS headers
-    # are reachable.  (Modules that call assisi_reflect already link ECS.)
+    # Compile generated sources as a separate OBJECT library.
+    # OBJECT libraries are always fully included in the final link — unlike
+    # static libraries, the linker never strips their translation units.
+    set(_obj_target "${_ARG_TARGET}-Generated")
+    add_library("${_obj_target}" OBJECT ${_generated_sources})
+
+    # Inherit the reflected module's include paths and compile settings
+    # (Options/Warnings/Perf come through transitively since the module
+    # links them PUBLIC via Assisi_apply_defaults).
+    target_link_libraries("${_obj_target}" PRIVATE "${_ARG_TARGET}")
+
+    # Register this OBJECT library globally so assisi_link_reflections()
+    # can gather all of them.
+    set_property(GLOBAL APPEND PROPERTY ASSISI_REFLECT_OBJECT_TARGETS "${_obj_target}")
+endfunction()
+
+# Call once on each final executable (or shared library) to force-include
+# all reflection registration code produced by assisi_reflect() calls.
+function(assisi_link_reflections target)
+    get_property(_reflect_targets GLOBAL PROPERTY ASSISI_REFLECT_OBJECT_TARGETS)
+    foreach(_rt ${_reflect_targets})
+        target_sources("${target}" PRIVATE "$<TARGET_OBJECTS:${_rt}>")
+    endforeach()
 endfunction()

--- a/modules/Core/include/Assisi/Core/Reflect/ComponentMeta.hpp
+++ b/modules/Core/include/Assisi/Core/Reflect/ComponentMeta.hpp
@@ -40,6 +40,14 @@ struct ComponentMeta
     std::function<void(void *scene_ptr, uint32_t entity_index, uint32_t entity_gen,
                        const nlohmann::json &j)>
         addToScene;
+
+    /// @brief Iterate all entities in a scene that have this component type.
+    ///
+    /// Type-erased for the same reason as addToScene.
+    ///   scene_ptr — pointer to an ECS::Scene, cast to void*.
+    ///   cb        — called once per entity: (entity_index, entity_gen, component_ptr).
+    std::function<void(void *scene_ptr, std::function<void(uint32_t, uint32_t, const void *)>)>
+        iterateEntities;
 };
 
 } // namespace Assisi::Core::Reflect

--- a/modules/Physics/CMakeLists.txt
+++ b/modules/Physics/CMakeLists.txt
@@ -22,4 +22,10 @@ target_link_libraries(Assisi-Physics
     Jolt::Jolt
 )
 
+assisi_reflect(
+  TARGET Assisi-Physics
+  HEADERS
+    include/Assisi/Physics/PhysicsComponents.hpp
+)
+
 add_library(Assisi::Physics ALIAS Assisi-Physics)

--- a/modules/Physics/include/Assisi/Physics/PhysicsComponents.hpp
+++ b/modules/Physics/include/Assisi/Physics/PhysicsComponents.hpp
@@ -1,9 +1,10 @@
 #pragma once
 
 /// @file PhysicsComponents.hpp
-/// @brief ECS component that links an entity to a Jolt rigid body.
+/// @brief ECS components for Jolt physics integration.
 
 #include <Assisi/Prelude.hpp>
+#include <Assisi/Math/GLM.hpp>
 #include <Jolt/Jolt.h>
 #include <Jolt/Physics/Body/BodyID.h>
 
@@ -17,6 +18,17 @@ namespace Assisi::Physics
 struct RigidBodyComponent
 {
     JPH::BodyID bodyId;
+};
+
+/// @brief Serializable descriptor for a box-shaped rigid body.
+///
+/// Stored in the level file; consumed at load time to create a
+/// RigidBodyComponent and the underlying Jolt body.  Not used at runtime.
+ACOMP()
+struct RigidBodyDescriptor
+{
+    AFIELD() glm::vec3 halfExtents{0.5f, 0.5f, 0.5f}; ///< Box half-extents in world units.
+    AFIELD() bool      isStatic = false;               ///< True = immovable static body.
 };
 
 } // namespace Assisi::Physics

--- a/modules/Physics/include/Assisi/Physics/PhysicsWorld.hpp
+++ b/modules/Physics/include/Assisi/Physics/PhysicsWorld.hpp
@@ -61,6 +61,9 @@ class PhysicsWorld
     /// @brief Teleports a body to the given position and rotation, and reactivates it.
     void SetBodyTransform(const RigidBodyComponent &body, glm::vec3 position, glm::quat rotation);
 
+    /// @brief Removes and destroys all bodies, resetting the world to an empty state.
+    void Clear();
+
     /// @brief Sets the gravity vector (default: {0, −9.81, 0}).
     void SetGravity(glm::vec3 gravity);
 

--- a/modules/Physics/src/PhysicsWorld.cpp
+++ b/modules/Physics/src/PhysicsWorld.cpp
@@ -120,7 +120,8 @@ struct PhysicsWorld::Impl
                                        static_cast<int>(std::thread::hardware_concurrency()) - 1};
     JPH::PhysicsSystem physicsSystem;
 
-    std::vector<JPH::BodyID> dynamicBodyIds; ///< Tracked so we can wake them on gravity changes.
+    std::vector<JPH::BodyID> allBodyIds;     ///< Every body ever added; used by Clear().
+    std::vector<JPH::BodyID> dynamicBodyIds; ///< Subset of allBodyIds; used to wake on gravity change.
 };
 
 // ---------------------------------------------------------------------------
@@ -165,17 +166,29 @@ RigidBodyComponent PhysicsWorld::AddBox(glm::vec3 position, glm::quat rotation, 
     JPH::BodyCreationSettings settings(
         new JPH::BoxShape(JPH::Vec3(halfExtents.x, halfExtents.y, halfExtents.z)),
         JPH::RVec3(position.x, position.y, position.z),
-        JPH::Quat(rotation.x, rotation.y, rotation.z, rotation.w), joltMotion, layer);
+        JPH::Quat(rotation.x, rotation.y, rotation.z, rotation.w).Normalized(), joltMotion, layer);
 
     JPH::BodyInterface &bodies = _impl->physicsSystem.GetBodyInterface();
     const JPH::BodyID bodyId = bodies.CreateAndAddBody(settings, JPH::EActivation::Activate);
 
+    _impl->allBodyIds.push_back(bodyId);
     if (motion == BodyMotion::Dynamic)
-    {
         _impl->dynamicBodyIds.push_back(bodyId);
-    }
 
     return RigidBodyComponent{bodyId};
+}
+
+void PhysicsWorld::Clear()
+{
+    JPH::BodyInterface &bodies = _impl->physicsSystem.GetBodyInterface();
+    for (const JPH::BodyID &id : _impl->allBodyIds)
+    {
+        if (bodies.IsAdded(id))
+            bodies.RemoveBody(id);
+        bodies.DestroyBody(id);
+    }
+    _impl->allBodyIds.clear();
+    _impl->dynamicBodyIds.clear();
 }
 
 void PhysicsWorld::Update(float deltaTime)

--- a/modules/Runtime/CMakeLists.txt
+++ b/modules/Runtime/CMakeLists.txt
@@ -8,11 +8,13 @@ target_sources(Assisi-Runtime
     "include/Assisi/Runtime/LightComponents.hpp"
     "include/Assisi/Runtime/LightingSystem.hpp"
     "include/Assisi/Runtime/Renderer.hpp"
+    "include/Assisi/Runtime/SceneSerializer.hpp"
     "include/Assisi/Runtime/Transform.hpp"
   PRIVATE
     "src/Camera.cpp"
     "src/LightingSystem.cpp"
     "src/Renderer.cpp"
+    "src/SceneSerializer.cpp"
 )
 
 target_include_directories(Assisi-Runtime

--- a/modules/Runtime/include/Assisi/Runtime/SceneSerializer.hpp
+++ b/modules/Runtime/include/Assisi/Runtime/SceneSerializer.hpp
@@ -1,0 +1,68 @@
+#pragma once
+
+/// @file SceneSerializer.hpp
+/// @brief JSON-based level file save/load for an ECS Scene.
+///
+/// All reflected (non-transient) component fields are persisted automatically
+/// via ComponentRegistry.  Unrecognised component names in a file are skipped
+/// with a warning so old levels remain loadable after component renames.
+///
+/// ## Format (version 1)
+/// @code{.json}
+/// {
+///   "version": 1,
+///   "entities": [
+///     {
+///       "components": {
+///         "TransformComponent": { "position": [0,0,0], "rotation": [1,0,0,0], "scale": [1,1,1] },
+///         "PointLightComponent": { "color": [1,1,1], "intensity": 100.0, "radius": 20.0 }
+///       }
+///     }
+///   ]
+/// }
+/// @endcode
+///
+/// Entity IDs are not persisted; loading always clears the scene first and
+/// allocates fresh sequential entities so generation numbers stay at zero.
+///
+/// ## Transient fields
+/// Fields marked AFIELD(transient) (e.g. GPU handles, raw pointers) are
+/// excluded from serialization.  Components where every field is transient
+/// (e.g. MeshRendererComponent) are saved as an empty object `{}` — their
+/// presence on the entity is preserved but no data is restored.
+
+#include <filesystem>
+#include <string_view>
+
+#include <nlohmann/json.hpp>
+
+#include <Assisi/ECS/Scene.hpp>
+
+namespace Assisi::Runtime
+{
+
+class SceneSerializer
+{
+  public:
+    /// @brief Serialize the entire scene to a JSON value.
+    static nlohmann::json Save(ECS::Scene &scene);
+
+    /// @brief Deserialize entities and components from a JSON value into the scene.
+    ///
+    /// Clears the scene before loading.  Only components registered in
+    /// ComponentRegistry are restored; unrecognised names are skipped with a warning.
+    static void Load(ECS::Scene &scene, const nlohmann::json &j);
+
+    /// @brief Write the scene to a JSON file at the given filesystem path.
+    ///
+    /// @return true on success, false if the file could not be opened.
+    static bool SaveToFile(ECS::Scene &scene, const std::filesystem::path &path);
+
+    /// @brief Load the scene from an asset-relative path via AssetSystem.
+    ///
+    /// @param assetPath  Virtual path relative to the asset root (e.g. "levels/main.json").
+    /// @return true on success, false on any IO or parse error.
+    static bool LoadFromFile(ECS::Scene &scene, std::string_view assetPath);
+};
+
+} // namespace Assisi::Runtime

--- a/modules/Runtime/src/SceneSerializer.cpp
+++ b/modules/Runtime/src/SceneSerializer.cpp
@@ -1,0 +1,109 @@
+#include <Assisi/Runtime/SceneSerializer.hpp>
+
+#include <Assisi/Core/AssetSystem.hpp>
+#include <Assisi/Core/Logger.hpp>
+#include <Assisi/Core/Reflect/ComponentRegistry.hpp>
+
+#include <fstream>
+#include <map>
+
+namespace Assisi::Runtime
+{
+
+nlohmann::json SceneSerializer::Save(ECS::Scene &scene)
+{
+    auto &registry = Core::Reflect::ComponentRegistry::Instance();
+
+    // Build a map from entity key → component JSON objects.
+    // Using std::map keeps entities in a deterministic (index-sorted) order.
+    std::map<uint64_t, nlohmann::json> entityMap;
+
+    for (const auto &meta : registry.All())
+    {
+        if (!meta.iterateEntities)
+            continue;
+
+        meta.iterateEntities(&scene, [&](uint32_t idx, uint32_t gen, const void *compPtr)
+        {
+            const uint64_t key = (static_cast<uint64_t>(gen) << 32) | idx;
+            entityMap[key]["components"][meta.name] = meta.serialize(compPtr);
+        });
+    }
+
+    nlohmann::json result;
+    result["version"]  = 1;
+    result["entities"] = nlohmann::json::array();
+
+    for (auto &[key, entityJson] : entityMap)
+        result["entities"].push_back(std::move(entityJson));
+
+    return result;
+}
+
+void SceneSerializer::Load(ECS::Scene &scene, const nlohmann::json &j)
+{
+    const int version = j.value("version", 0);
+    if (version != 1)
+    {
+        Core::Log::Error("SceneSerializer: unsupported level file version {}", version);
+        return;
+    }
+
+    auto &registry = Core::Reflect::ComponentRegistry::Instance();
+
+    scene.Clear();
+
+    for (const auto &entityJson : j.at("entities"))
+    {
+        const ECS::Entity e = scene.Create();
+
+        if (!entityJson.contains("components"))
+            continue;
+
+        for (const auto &[compName, compData] : entityJson.at("components").items())
+        {
+            const auto *meta = registry.Find(compName);
+            if (!meta)
+            {
+                Core::Log::Warn("SceneSerializer: unknown component '{}' - skipped", compName);
+                continue;
+            }
+            meta->addToScene(&scene, e.index, e.generation, compData);
+        }
+    }
+}
+
+bool SceneSerializer::SaveToFile(ECS::Scene &scene, const std::filesystem::path &path)
+{
+    std::ofstream f(path);
+    if (!f.is_open())
+    {
+        Core::Log::Error("SceneSerializer: cannot open '{}' for writing", path.string());
+        return false;
+    }
+    f << Save(scene).dump(2);
+    return f.good();
+}
+
+bool SceneSerializer::LoadFromFile(ECS::Scene &scene, std::string_view assetPath)
+{
+    const auto text = Core::AssetSystem::ReadText(assetPath);
+    if (!text)
+    {
+        Core::Log::Error("SceneSerializer: cannot read asset '{}'", assetPath);
+        return false;
+    }
+
+    try
+    {
+        Load(scene, nlohmann::json::parse(*text));
+        return true;
+    }
+    catch (const nlohmann::json::exception &ex)
+    {
+        Core::Log::Error("SceneSerializer: JSON error in '{}': {}", assetPath, ex.what());
+        return false;
+    }
+}
+
+} // namespace Assisi::Runtime

--- a/tools/reflectgen/reflectgen.py
+++ b/tools/reflectgen/reflectgen.py
@@ -417,6 +417,12 @@ static const bool {var_name} = []() -> bool
         [](void* scene_ptr, uint32_t entity_index, uint32_t entity_gen, const nlohmann::json& j)
         {{
 {deserialize}
+        }},
+        [](void* scene_ptr, std::function<void(uint32_t, uint32_t, const void*)> cb)
+        {{
+            auto& scene = *static_cast<Assisi::ECS::Scene*>(scene_ptr);
+            for (auto [e, comp] : scene.Query<T>())
+                cb(e.index, e.generation, &comp);
         }}
     }});
     return true;


### PR DESCRIPTION
…sandbox level loader UI

- Extend the reflection system: add `iterateEntities` callback to `ComponentMeta` and generate it in reflectgen.py so `ComponentRegistry` can enumerate every component in a scene without knowing its type
- Add `SceneSerializer` (Runtime module) that saves/loads scenes generically via the registry, writing JSON to custom `.alvl` files
- Fix static initializer stripping on MSVC: change `assisi_reflect()` to compile generated registration code into OBJECT libraries (bypassing the linker's unreferenced-obj-file pruning) and add `assisi_link_reflections()` to pull those objects into executables
- Add `RigidBodyDescriptor` (serializable ACOMP with `halfExtents` + `isStatic`) to separate physics description from the non-serializable Jolt `BodyID` handle in `RigidBodyComponent`
- Add `PhysicsWorld::Clear()` to remove and destroy all tracked bodies; call it on level reload so stale Jolt bodies do not persist between loads; normalize incoming quaternions in `AddBox` to prevent Jolt debug-mode assertions on JSON-rounded rotations
- Rewrite sandbox: remove all hardcoded scene setup and runtime spawn/edit ImGui controls; add Levels window with a file-list combo populated from `assets/levels/*.alvl`, and Load / Save / Save As buttons
- Add `assets/levels/Test.alvl` as the initial test level (directional light, static floor, dynamic cubes, point lights)