### PR TITLE
Convert Camera to ECS: replace class with free functions and CameraCo…

### DIFF
--- a/apps/sandbox/src/main.cpp
+++ b/apps/sandbox/src/main.cpp
@@ -11,6 +11,7 @@
 #include <Assisi/Render/DefaultMeshes.hpp>
 #include <Assisi/Render/OpenGL/MeshBuffer.hpp>
 #include <Assisi/Render/Shader.hpp>
+#include <Assisi/ECS/Scene.hpp>
 #include <Assisi/Runtime/Camera.hpp>
 #include <Assisi/Runtime/Components.hpp>
 #include <Assisi/Runtime/LightingSystem.hpp>
@@ -50,17 +51,16 @@ class SandboxApp : public Assisi::App::Application
 
     Assisi::Render::OpenGL::MeshBuffer _cubeMesh;
     Assisi::Render::Shader             _shader;
-    Assisi::Runtime::Camera            _camera;
     Assisi::Runtime::LightingSystem    _lighting;
     glm::mat4                          _projection{1.f};
 
-    static constexpr float kNearZ = 0.1f;
-    static constexpr float kFarZ  = 200.f;
+    // Camera entity lives in its own scene so level loads don't destroy it.
+    Assisi::ECS::Scene  _cameraScene;
+    Assisi::ECS::Entity _cameraEntity = Assisi::ECS::NullEntity;
 
-    // Camera control state
-    float _yaw        = -116.6f;
-    float _pitch      =  -24.1f;
-    float _fovDegrees =   60.f;
+    // Camera controller state (Euler angles, authoritative source for orientation).
+    float _yaw   = -116.6f;
+    float _pitch =  -24.1f;
 
     static constexpr float kMoveSpeed        = 8.f;   // units/s
     static constexpr float kMouseSensitivity = 0.1f;  // degrees/pixel
@@ -86,13 +86,33 @@ void SandboxApp::OnStart()
         return;
     }
 
-    _camera = Assisi::Runtime::Camera({5.f, 5.f, 10.f}, {0.f, 0.f, 0.f});
+    // Create camera entity — lives in a separate scene so level loads don't destroy it.
+    {
+        const glm::vec3 camPos{5.f, 5.f, 10.f};
+        const glm::vec3 forward = glm::normalize(-camPos); // look toward origin
+
+        _pitch = glm::degrees(glm::asin(forward.y));
+        _yaw   = glm::degrees(glm::atan(forward.z, forward.x));
+
+        const glm::vec3 right = glm::normalize(glm::cross(forward, glm::vec3{0.f, 1.f, 0.f}));
+        const glm::vec3 up    = glm::normalize(glm::cross(right, forward));
+
+        Assisi::Runtime::TransformComponent camTransform;
+        camTransform.position = camPos;
+        camTransform.rotation = glm::quat_cast(glm::mat3(right, up, -forward));
+
+        _cameraEntity = _cameraScene.Create();
+        (void)_cameraScene.Add<Assisi::Runtime::TransformComponent>(_cameraEntity, camTransform);
+        (void)_cameraScene.Add<Assisi::Runtime::CameraComponent>(_cameraEntity,
+                                                                  Assisi::Runtime::CameraComponent{60.f, 0.1f, 200.f, true});
+    }
 
     // Lighting system — must be initialised after the OpenGL context is ready.
     {
-        const auto size = GetWindow().GetFramebufferSize();
-        _projection     = MakeProjection(_fovDegrees, kNearZ, kFarZ);
-        if (!_lighting.Initialize(size.Width, size.Height, kNearZ, kFarZ, _projection))
+        const auto *cam = _cameraScene.Get<Assisi::Runtime::CameraComponent>(_cameraEntity);
+        const auto  size = GetWindow().GetFramebufferSize();
+        _projection = MakeProjection(cam->fovDegrees, cam->nearZ, cam->farZ);
+        if (!_lighting.Initialize(size.Width, size.Height, cam->nearZ, cam->farZ, _projection))
         {
             Assisi::Core::Log::Error("Failed to initialise LightingSystem.");
             RequestClose();
@@ -101,18 +121,14 @@ void SandboxApp::OnStart()
         _lighting.SetupMeshShader(_shader);
     }
 
-    // Derive initial yaw/pitch from camera direction so mouse control is consistent.
-    const glm::vec3 forward = _camera.ForwardDirection();
-    _pitch = glm::degrees(glm::asin(forward.y));
-    _yaw   = glm::degrees(glm::atan(forward.z, forward.x));
-
     ScanLevels();
 }
 
 void SandboxApp::OnResize(int width, int height)
 {
-    _projection = MakeProjection(_fovDegrees, kNearZ, kFarZ);
-    _lighting.Resize(width, height, kNearZ, kFarZ, _projection);
+    const auto *cam = _cameraScene.Get<Assisi::Runtime::CameraComponent>(_cameraEntity);
+    _projection = MakeProjection(cam->fovDegrees, cam->nearZ, cam->farZ);
+    _lighting.Resize(width, height, cam->nearZ, cam->farZ, _projection);
     _lighting.SetupMeshShader(_shader);
 }
 
@@ -153,8 +169,12 @@ void SandboxApp::OnUpdate(float dt)
             glm::sin(glm::radians(_pitch)),
             glm::cos(glm::radians(_pitch)) * glm::sin(glm::radians(_yaw))};
 
+        const glm::vec3 right = glm::normalize(glm::cross(forward, glm::vec3{0.f, 1.f, 0.f}));
+        const glm::vec3 up    = glm::normalize(glm::cross(right, forward));
+
+        auto *camTransform = _cameraScene.Get<Assisi::Runtime::TransformComponent>(_cameraEntity);
+
         // --- WASD + Space/Ctrl movement ---
-        const glm::vec3 right = _camera.RightDirection();
         glm::vec3 move{0.f};
         if (input.IsKeyDown(Assisi::Window::Key::W))           { move += forward; }
         if (input.IsKeyDown(Assisi::Window::Key::S))           { move -= forward; }
@@ -163,12 +183,10 @@ void SandboxApp::OnUpdate(float dt)
         if (input.IsKeyDown(Assisi::Window::Key::Space))       { move.y += 1.f; }
         if (input.IsKeyDown(Assisi::Window::Key::LeftControl)) { move.y -= 1.f; }
 
-        glm::vec3 pos = _camera.WorldPosition();
         if (glm::length(move) > 0.f)
-            pos += glm::normalize(move) * (kMoveSpeed * dt);
+            camTransform->position += glm::normalize(move) * (kMoveSpeed * dt);
 
-        _camera.SetWorldPosition(pos);
-        _camera.SetLookAtTarget(pos + forward);
+        camTransform->rotation = glm::quat_cast(glm::mat3(right, up, -forward));
     }
 
     // --- Scroll to adjust FOV ---
@@ -177,22 +195,26 @@ void SandboxApp::OnUpdate(float dt)
         const float scroll = input.ScrollDelta();
         if (scroll != 0.f)
         {
-            _fovDegrees = glm::clamp(_fovDegrees - (scroll * 5.f), 10.f, 120.f);
-            _projection = MakeProjection(_fovDegrees, kNearZ, kFarZ);
+            auto *cam = _cameraScene.Get<Assisi::Runtime::CameraComponent>(_cameraEntity);
+            cam->fovDegrees = glm::clamp(cam->fovDegrees - (scroll * 5.f), 10.f, 120.f);
+            _projection = MakeProjection(cam->fovDegrees, cam->nearZ, cam->farZ);
         }
     }
 }
 
 void SandboxApp::OnRender()
 {
-    _lighting.Update(*_scene, _camera.ViewMatrix());
+    const auto *camTransform = _cameraScene.Get<Assisi::Runtime::TransformComponent>(_cameraEntity);
+    const glm::mat4 view = Assisi::Runtime::ViewMatrix(*camTransform);
+
+    _lighting.Update(*_scene, view);
 
     _shader.Use();
-    _shader.SetVec3("uViewPos", _camera.WorldPosition());
+    _shader.SetVec3("uViewPos", camTransform->position);
     _shader.SetVec3("uAmbient", {0.03f, 0.03f, 0.03f});
     _shader.SetInt("uDirLightCount", static_cast<int>(_lighting.DirLightCount()));
 
-    Assisi::Runtime::DrawScene(*_scene, _camera, _projection, _shader);
+    Assisi::Runtime::DrawScene(*_scene, view, _projection, _shader);
 }
 
 void SandboxApp::OnImGui()

--- a/modules/Runtime/include/Assisi/Runtime/Camera.hpp
+++ b/modules/Runtime/include/Assisi/Runtime/Camera.hpp
@@ -1,61 +1,40 @@
 #pragma once
 
 /// @file Camera.hpp
-/// @brief A look-at camera that produces a view matrix from world-space state.
+/// @brief Camera utility functions derived from ECS components.
+///
+/// A camera is represented as an entity with both a TransformComponent
+/// (position and orientation) and a CameraComponent (projection parameters).
+///
+/// Orientation convention: the camera looks along its local -Z axis.
+/// Set TransformComponent::rotation so that `rotation * (0,0,-1)` points in
+/// the desired view direction, or use glm::quat_cast on a basis matrix built
+/// from (right, up, -forward).
 
 #include <Assisi/Math/GLM.hpp>
+#include <Assisi/Runtime/Components.hpp>
 
 namespace Assisi::Runtime
 {
-/// @brief Represents a view camera defined by a position and a look-at target.
+
+/// @brief Returns the view matrix derived from the transform's position and rotation.
 ///
-/// The view matrix is computed on-demand from the stored world-space state.
-/// Roll is resolved using the configurable up direction.
-class Camera
-{
-  public:
-    Camera() = default;
+/// The camera looks along its local -Z axis (OpenGL convention).
+glm::mat4 ViewMatrix(const TransformComponent &transform);
 
-    /// @param worldPosition  Camera position in world space.
-    /// @param lookAtTarget   World-space point the camera looks at.
-    explicit Camera(const glm::vec3 &worldPosition, const glm::vec3 &lookAtTarget)
-        : _worldPosition(worldPosition), _lookAtTarget(lookAtTarget)
-    {
-    }
+/// @brief Returns a perspective projection matrix from the camera's parameters.
+///
+/// @param camera      Camera projection parameters (fovDegrees, nearZ, farZ).
+/// @param aspectRatio Viewport width / height.
+glm::mat4 ProjectionMatrix(const CameraComponent &camera, float aspectRatio);
 
-    /* World-space state accessors */
-    glm::vec3 WorldPosition() const { return _worldPosition; }
-    glm::vec3 LookAtTarget() const { return _lookAtTarget; }
-    glm::vec3 WorldUpDirection() const { return _worldUpDirection; }
+/// @brief World-space forward direction (-Z axis rotated by the transform's quaternion).
+glm::vec3 ForwardDirection(const TransformComponent &transform);
 
-    /* World-space mutators */
-    void SetWorldPosition(const glm::vec3 &worldPosition) { _worldPosition = worldPosition; }
+/// @brief World-space right direction (+X axis rotated by the transform's quaternion).
+glm::vec3 RightDirection(const TransformComponent &transform);
 
-    void SetLookAtTarget(const glm::vec3 &lookAtTarget) { _lookAtTarget = lookAtTarget; }
+/// @brief World-space up direction (+Y axis rotated by the transform's quaternion).
+glm::vec3 UpDirection(const TransformComponent &transform);
 
-    /// @brief Sets the reference up vector used to resolve camera roll.
-    void SetWorldUpDirection(const glm::vec3 &worldUpDirection) { _worldUpDirection = worldUpDirection; }
-
-    /// @brief Returns the view matrix computed from current position, target, and up direction.
-    glm::mat4 ViewMatrix() const { return glm::lookAt(_worldPosition, _lookAtTarget, _worldUpDirection); }
-
-    /// @name Derived camera-space directions
-    /// These are recomputed each call; cache if used frequently.
-    ///@{
-    glm::vec3 ForwardDirection() const { return glm::normalize(_lookAtTarget - _worldPosition); }
-
-    /// @brief Right axis, orthogonal to forward and the world up reference.
-    glm::vec3 RightDirection() const { return glm::normalize(glm::cross(ForwardDirection(), _worldUpDirection)); }
-
-    /// @brief True camera up, orthogonal to both right and forward.
-    glm::vec3 UpDirection() const { return glm::normalize(glm::cross(RightDirection(), ForwardDirection())); }
-    ///@}
-
-  private:
-    glm::vec3 _worldPosition{0.0f, 0.0f, 3.0f};
-    glm::vec3 _lookAtTarget{0.0f, 0.0f, 0.0f};
-
-    /// @brief Reference direction used to resolve camera roll.
-    glm::vec3 _worldUpDirection{0.0f, 1.0f, 0.0f};
-};
 } // namespace Assisi::Runtime

--- a/modules/Runtime/include/Assisi/Runtime/Components.hpp
+++ b/modules/Runtime/include/Assisi/Runtime/Components.hpp
@@ -45,4 +45,20 @@ struct MeshRendererComponent
     AFIELD(transient) unsigned int roughnessTextureId = 0u;
 };
 
+/// @brief Projection and activation parameters for a camera entity.
+///
+/// Pair with TransformComponent to form a complete camera: the TransformComponent
+/// provides world-space position and orientation; this component stores projection
+/// settings and identifies which camera is active.
+///
+/// Call Runtime::ViewMatrix(transform) and Runtime::ProjectionMatrix(camera, aspect)
+/// to obtain the matrices needed for rendering.
+struct CameraComponent
+{
+    float fovDegrees = 60.f;  ///< Vertical field of view in degrees.
+    float nearZ      = 0.1f;  ///< Near clip plane distance.
+    float farZ       = 200.f; ///< Far clip plane distance.
+    bool  isActive   = false; ///< True for the scene's active camera.
+};
+
 } // namespace Assisi::Runtime

--- a/modules/Runtime/include/Assisi/Runtime/Renderer.hpp
+++ b/modules/Runtime/include/Assisi/Runtime/Renderer.hpp
@@ -6,7 +6,6 @@
 #include <Assisi/ECS/Scene.hpp>
 #include <Assisi/Math/GLM.hpp>
 #include <Assisi/Render/Shader.hpp>
-#include <Assisi/Runtime/Camera.hpp>
 
 namespace Assisi::Runtime
 {
@@ -25,10 +24,10 @@ namespace Assisi::Runtime
 /// Entities whose MeshRendererComponent::mesh is null are skipped silently.
 ///
 /// @param scene       ECS scene to query.
-/// @param camera      Provides the view matrix.
-/// @param projection  Projection matrix (e.g. glm::perspective).
+/// @param view        View matrix (e.g. from Runtime::ViewMatrix).
+/// @param projection  Projection matrix (e.g. from Runtime::ProjectionMatrix).
 /// @param shader      Shader program to use; must already be loaded.
-void DrawScene(Assisi::ECS::Scene &scene, const Camera &camera, const glm::mat4 &projection,
+void DrawScene(Assisi::ECS::Scene &scene, const glm::mat4 &view, const glm::mat4 &projection,
                Assisi::Render::Shader &shader);
 
 } // namespace Assisi::Runtime

--- a/modules/Runtime/src/Camera.cpp
+++ b/modules/Runtime/src/Camera.cpp
@@ -1,0 +1,33 @@
+#include <Assisi/Runtime/Camera.hpp>
+
+namespace Assisi::Runtime
+{
+
+glm::mat4 ViewMatrix(const TransformComponent &transform)
+{
+    const glm::vec3 forward = transform.rotation * glm::vec3(0.f, 0.f, -1.f);
+    const glm::vec3 up      = transform.rotation * glm::vec3(0.f, 1.f,  0.f);
+    return glm::lookAt(transform.position, transform.position + forward, up);
+}
+
+glm::mat4 ProjectionMatrix(const CameraComponent &camera, float aspectRatio)
+{
+    return glm::perspective(glm::radians(camera.fovDegrees), aspectRatio, camera.nearZ, camera.farZ);
+}
+
+glm::vec3 ForwardDirection(const TransformComponent &transform)
+{
+    return transform.rotation * glm::vec3(0.f, 0.f, -1.f);
+}
+
+glm::vec3 RightDirection(const TransformComponent &transform)
+{
+    return transform.rotation * glm::vec3(1.f, 0.f, 0.f);
+}
+
+glm::vec3 UpDirection(const TransformComponent &transform)
+{
+    return transform.rotation * glm::vec3(0.f, 1.f, 0.f);
+}
+
+} // namespace Assisi::Runtime

--- a/modules/Runtime/src/Renderer.cpp
+++ b/modules/Runtime/src/Renderer.cpp
@@ -9,11 +9,11 @@
 namespace Assisi::Runtime
 {
 
-void DrawScene(Assisi::ECS::Scene &scene, const Camera &camera, const glm::mat4 &projection,
+void DrawScene(Assisi::ECS::Scene &scene, const glm::mat4 &view, const glm::mat4 &projection,
                Assisi::Render::Shader &shader)
 {
     shader.Use();
-    shader.SetMat4("uView", camera.ViewMatrix());
+    shader.SetMat4("uView", view);
     shader.SetMat4("uProjection", projection);
 
     // Bind sampler uniforms to their fixed texture units


### PR DESCRIPTION
…mponent

Replace the look-at Camera class with a CameraComponent struct (fovDegrees, nearZ, farZ, isActive) paired with TransformComponent for orientation. Camera utility free functions (ViewMatrix, ProjectionMatrix, ForwardDirection, RightDirection, UpDirection) now operate on ECS components directly. DrawScene drops the Camera& parameter in favour of pre-computed mat4 view and projection matrices. The sandbox camera entity lives in a dedicated scene so level loads cannot destroy it.