### PR TITLE
Add EventQueue, SystemRegistry, GameApplication, and DestroyTag (ENG-28)

### DIFF
--- a/apps/sandbox/CMakeLists.txt
+++ b/apps/sandbox/CMakeLists.txt
@@ -16,9 +16,29 @@ target_link_libraries(Assisi-Sandbox
 
 assisi_link_reflections(Assisi-Sandbox)
 
-add_custom_command(TARGET Assisi-Sandbox POST_BUILD
+# Glob all asset files so the copy re-runs whenever any file changes.
+# CONFIGURE_DEPENDS also triggers a re-configure when files are added or removed.
+file(GLOB_RECURSE _assisi_assets
+    CONFIGURE_DEPENDS
+    LIST_DIRECTORIES false
+    "${CMAKE_SOURCE_DIR}/assets/*"
+)
+
+set(_assets_stamp "${CMAKE_CURRENT_BINARY_DIR}/assets.stamp")
+
+add_custom_command(
+    OUTPUT "${_assets_stamp}"
     COMMAND ${CMAKE_COMMAND} -E copy_directory
         "${CMAKE_SOURCE_DIR}/assets"
         "$<TARGET_FILE_DIR:Assisi-Sandbox>/assets"
-    COMMENT "Copying assets next to Assisi-Sandbox"
+    COMMAND ${CMAKE_COMMAND} -E touch "${_assets_stamp}"
+    DEPENDS ${_assisi_assets}
+    COMMENT "Copying assets to build directory"
+    VERBATIM
 )
+
+add_custom_target(Assisi-CopyAssets ALL
+    DEPENDS "${_assets_stamp}"
+)
+
+add_dependencies(Assisi-Sandbox Assisi-CopyAssets)

--- a/apps/sandbox/src/main.cpp
+++ b/apps/sandbox/src/main.cpp
@@ -2,8 +2,10 @@
 /// @brief Assisi Sandbox — level viewer built on the Application layer.
 
 #include <Assisi/App/Application.hpp>
+#include <Assisi/App/SystemRegistry.hpp>
 
 #include <Assisi/Core/AssetSystem.hpp>
+#include <Assisi/Core/EventQueue.hpp>
 #include <Assisi/Core/Logger.hpp>
 #include <Assisi/Core/Reflect/ComponentRegistry.hpp>
 #include <Assisi/ECS/SceneRegistry.hpp>
@@ -30,6 +32,18 @@
 #include <string>
 
 // ---------------------------------------------------------------------------
+// Events
+// ---------------------------------------------------------------------------
+
+/// @brief Emitted when the user clicks to select (or deselect) an entity.
+/// NullEntity means the click landed on empty space.
+AEVENT()
+struct EntitySelectionChangedEvent
+{
+    Assisi::ECS::Entity entity;
+};
+
+// ---------------------------------------------------------------------------
 // SandboxApp
 // ---------------------------------------------------------------------------
 
@@ -44,13 +58,34 @@ class SandboxApp : public Assisi::App::Application
     void OnResize(int width, int height) override;
 
   private:
+    // --- Setup ---
+    void SetupCamera();
+    void SetupLighting();
+
+    // --- Per-frame helpers ---
+    void HandleEntityPicking();
+    void UpdateCamera(float dt);
+
+    // --- ImGui panels ---
+    void DrawDiagnosticsWindow();
+    void DrawLevelsWindow();
+    void DrawInspector();
+
+    // --- Inspector helpers ---
+    bool EditComponentFields(void *mut, const Assisi::Core::Reflect::ComponentMeta &meta);
+    void HandlePhysicsEditing(bool anyFieldEdited);
+
+    // --- Level management ---
     void ScanLevels();
     void LoadLevel(const std::string &name);
     void SaveLevel(const std::string &name);
 
     Assisi::ECS::Entity PickEntity(glm::vec2 mousePos);
-    void                DrawInspector();
 
+    // --- Systems ---
+    Assisi::App::SystemRegistry _systems;
+
+    // --- State ---
     Assisi::ECS::SceneRegistry         _scenes;
     Assisi::ECS::Scene                *_scene = nullptr;
     Assisi::Physics::PhysicsWorld      _physics;
@@ -60,16 +95,14 @@ class SandboxApp : public Assisi::App::Application
     Assisi::Runtime::LightingSystem    _lighting;
     glm::mat4                          _projection{1.f};
 
-    // Camera entity lives in its own scene so level loads don't destroy it.
     Assisi::ECS::Scene  _cameraScene;
     Assisi::ECS::Entity _cameraEntity = Assisi::ECS::NullEntity;
 
-    // Camera controller state (Euler angles, authoritative source for orientation).
     float _yaw   = -116.6f;
     float _pitch =  -24.1f;
 
-    static constexpr float kMoveSpeed        = 8.f;   // units/s
-    static constexpr float kMouseSensitivity = 0.1f;  // degrees/pixel
+    static constexpr float kMoveSpeed        = 8.f;
+    static constexpr float kMouseSensitivity = 0.1f;
 
     Assisi::ECS::Entity _selectedEntity = Assisi::ECS::NullEntity;
     bool                _wasDragging    = false;
@@ -80,11 +113,52 @@ class SandboxApp : public Assisi::App::Application
 };
 
 // ---------------------------------------------------------------------------
+// Setup helpers
+// ---------------------------------------------------------------------------
+
+void SandboxApp::SetupCamera()
+{
+    const glm::vec3 camPos{5.f, 5.f, 10.f};
+    const glm::vec3 forward = glm::normalize(-camPos);
+
+    _pitch = glm::degrees(glm::asin(forward.y));
+    _yaw   = glm::degrees(glm::atan(forward.z, forward.x));
+
+    const glm::vec3 right = glm::normalize(glm::cross(forward, glm::vec3{0.f, 1.f, 0.f}));
+    const glm::vec3 up    = glm::normalize(glm::cross(right, forward));
+
+    Assisi::Runtime::TransformComponent camTransform;
+    camTransform.position = camPos;
+    camTransform.rotation = glm::quat_cast(glm::mat3(right, up, -forward));
+
+    _cameraEntity = _cameraScene.Create();
+    (void)_cameraScene.Add<Assisi::Runtime::TransformComponent>(_cameraEntity, camTransform);
+    (void)_cameraScene.Add<Assisi::Runtime::CameraComponent>(
+        _cameraEntity, Assisi::Runtime::CameraComponent{60.f, 0.1f, 200.f, true});
+}
+
+void SandboxApp::SetupLighting()
+{
+    const auto *cam  = _cameraScene.Get<Assisi::Runtime::CameraComponent>(_cameraEntity);
+    const auto  size = GetWindow().GetFramebufferSize();
+    _projection      = MakeProjection(cam->fovDegrees, cam->nearZ, cam->farZ);
+
+    if (!_lighting.Initialize(size.Width, size.Height, cam->nearZ, cam->farZ, _projection))
+    {
+        Assisi::Core::Log::Error("Failed to initialise LightingSystem.");
+        RequestClose();
+        return;
+    }
+    _lighting.SetupMeshShader(_shader);
+}
+
+// ---------------------------------------------------------------------------
+// Lifecycle
+// ---------------------------------------------------------------------------
 
 void SandboxApp::OnStart()
 {
-    _scene = _scenes.Create("Main").value();
-
+    _scene    = _scenes.Create("Main").value();
     _cubeMesh = Assisi::Render::OpenGL::MeshBuffer(Assisi::Render::CreateUnitCubeMesh());
 
     _shader = Assisi::Render::Shader("shaders/mesh.vert", "shaders/mesh.frag");
@@ -95,48 +169,34 @@ void SandboxApp::OnStart()
         return;
     }
 
-    // Create camera entity — lives in a separate scene so level loads don't destroy it.
-    {
-        const glm::vec3 camPos{5.f, 5.f, 10.f};
-        const glm::vec3 forward = glm::normalize(-camPos); // look toward origin
-
-        _pitch = glm::degrees(glm::asin(forward.y));
-        _yaw   = glm::degrees(glm::atan(forward.z, forward.x));
-
-        const glm::vec3 right = glm::normalize(glm::cross(forward, glm::vec3{0.f, 1.f, 0.f}));
-        const glm::vec3 up    = glm::normalize(glm::cross(right, forward));
-
-        Assisi::Runtime::TransformComponent camTransform;
-        camTransform.position = camPos;
-        camTransform.rotation = glm::quat_cast(glm::mat3(right, up, -forward));
-
-        _cameraEntity = _cameraScene.Create();
-        (void)_cameraScene.Add<Assisi::Runtime::TransformComponent>(_cameraEntity, camTransform);
-        (void)_cameraScene.Add<Assisi::Runtime::CameraComponent>(_cameraEntity,
-                                                                  Assisi::Runtime::CameraComponent{60.f, 0.1f, 200.f, true});
-    }
-
-    // Lighting system — must be initialised after the OpenGL context is ready.
-    {
-        const auto *cam = _cameraScene.Get<Assisi::Runtime::CameraComponent>(_cameraEntity);
-        const auto  size = GetWindow().GetFramebufferSize();
-        _projection = MakeProjection(cam->fovDegrees, cam->nearZ, cam->farZ);
-        if (!_lighting.Initialize(size.Width, size.Height, cam->nearZ, cam->farZ, _projection))
-        {
-            Assisi::Core::Log::Error("Failed to initialise LightingSystem.");
-            RequestClose();
-            return;
-        }
-        _lighting.SetupMeshShader(_shader);
-    }
-
+    SetupCamera();
+    SetupLighting();
     ScanLevels();
+
+    // --- Systems ---
+    _systems.Register(Assisi::App::SystemPhase::Update, "EntityPicking",
+                      [this](Assisi::App::SystemContext &) { HandleEntityPicking(); });
+
+    _systems.Register(Assisi::App::SystemPhase::Update, "CameraController",
+                      [this](Assisi::App::SystemContext &ctx) { UpdateCamera(ctx.dt); })
+        .After("EntityPicking");
+
+    _systems.Register(Assisi::App::SystemPhase::PostUpdate, "ProcessEntitySelection",
+                      [this](Assisi::App::SystemContext &)
+                      {
+                          for (const auto &e :
+                               Assisi::Core::EventQueue::Instance()
+                                   .Read<EntitySelectionChangedEvent>())
+                          {
+                              _selectedEntity = e.entity;
+                          }
+                      });
 }
 
 void SandboxApp::OnResize(int width, int height)
 {
     const auto *cam = _cameraScene.Get<Assisi::Runtime::CameraComponent>(_cameraEntity);
-    _projection = MakeProjection(cam->fovDegrees, cam->nearZ, cam->farZ);
+    _projection     = MakeProjection(cam->fovDegrees, cam->nearZ, cam->farZ);
     _lighting.Resize(width, height, cam->nearZ, cam->farZ, _projection);
     _lighting.SetupMeshShader(_shader);
 }
@@ -147,32 +207,33 @@ void SandboxApp::OnFixedUpdate(float dt)
     _physics.SyncTransforms(*_scene);
 }
 
-void SandboxApp::OnUpdate(float dt)
-{
-    auto       &input         = GetInput();
-    const bool  imguiWantsMouse = ImGui::GetIO().WantCaptureMouse;
+// ---------------------------------------------------------------------------
+// Per-frame helpers
+// ---------------------------------------------------------------------------
 
-    // --- RMB: engage / disengage camera look ---
+void SandboxApp::HandleEntityPicking()
+{
+    auto &input = GetInput();
+    if (input.IsMouseButtonPressed(Assisi::Window::MouseButton::Left) &&
+        !input.IsMouseCaptured() && !ImGui::GetIO().WantCaptureMouse)
+    {
+        Assisi::Core::EventQueue::Instance().Push(
+            EntitySelectionChangedEvent{PickEntity(input.MousePosition())});
+    }
+}
+
+void SandboxApp::UpdateCamera(float dt)
+{
+    auto      &input          = GetInput();
+    const bool imguiWantsMouse = ImGui::GetIO().WantCaptureMouse;
+
     if (input.IsMouseButtonPressed(Assisi::Window::MouseButton::Right) && !imguiWantsMouse)
         input.SetMouseCaptured(true);
     if (input.IsMouseButtonReleased(Assisi::Window::MouseButton::Right))
         input.SetMouseCaptured(false);
 
-    // --- Escape: quit (capture is managed by RMB; don't intercept while ImGui has keyboard) ---
-    if (input.IsKeyPressed(Assisi::Window::Key::Escape) && !ImGui::GetIO().WantCaptureKeyboard)
-        RequestClose();
-
-    // --- LMB (not captured, not over ImGui): pick entity ---
-    if (input.IsMouseButtonPressed(Assisi::Window::MouseButton::Left) &&
-        !input.IsMouseCaptured() && !imguiWantsMouse)
-    {
-        _selectedEntity = PickEntity(input.MousePosition());
-    }
-
-    // --- Camera movement while RMB is held ---
     if (input.IsMouseCaptured())
     {
-        // Mouse rotation
         const glm::vec2 delta = input.MouseDelta();
         _yaw   += delta.x * kMouseSensitivity;
         _pitch -= delta.y * kMouseSensitivity;
@@ -186,9 +247,9 @@ void SandboxApp::OnUpdate(float dt)
         const glm::vec3 right = glm::normalize(glm::cross(forward, glm::vec3{0.f, 1.f, 0.f}));
         const glm::vec3 up    = glm::normalize(glm::cross(right, forward));
 
-        auto *camTransform = _cameraScene.Get<Assisi::Runtime::TransformComponent>(_cameraEntity);
+        auto *camTransform =
+            _cameraScene.Get<Assisi::Runtime::TransformComponent>(_cameraEntity);
 
-        // WASD + Space/Ctrl movement
         glm::vec3 move{0.f};
         if (input.IsKeyDown(Assisi::Window::Key::W))           { move += forward; }
         if (input.IsKeyDown(Assisi::Window::Key::S))           { move -= forward; }
@@ -203,17 +264,26 @@ void SandboxApp::OnUpdate(float dt)
         camTransform->rotation = glm::quat_cast(glm::mat3(right, up, -forward));
     }
 
-    // --- Scroll to adjust FOV ---
     if (!imguiWantsMouse)
     {
         const float scroll = input.ScrollDelta();
         if (scroll != 0.f)
         {
-            auto *cam = _cameraScene.Get<Assisi::Runtime::CameraComponent>(_cameraEntity);
+            auto *cam       = _cameraScene.Get<Assisi::Runtime::CameraComponent>(_cameraEntity);
             cam->fovDegrees = glm::clamp(cam->fovDegrees - (scroll * 5.f), 10.f, 120.f);
-            _projection = MakeProjection(cam->fovDegrees, cam->nearZ, cam->farZ);
+            _projection     = MakeProjection(cam->fovDegrees, cam->nearZ, cam->farZ);
         }
     }
+}
+
+void SandboxApp::OnUpdate(float dt)
+{
+    auto &input = GetInput();
+    if (input.IsKeyPressed(Assisi::Window::Key::Escape) && !ImGui::GetIO().WantCaptureKeyboard)
+        RequestClose();
+
+    _systems.Run(Assisi::App::SystemPhase::Update,     {*_scene, dt, input});
+    _systems.Run(Assisi::App::SystemPhase::PostUpdate,  {*_scene, dt, input});
 }
 
 void SandboxApp::OnRender()
@@ -221,8 +291,8 @@ void SandboxApp::OnRender()
     Assisi::Runtime::PropagateTransforms(_cameraScene);
     Assisi::Runtime::PropagateTransforms(*_scene);
 
-    const auto *camTransform = _cameraScene.Get<Assisi::Runtime::TransformComponent>(_cameraEntity);
-    const glm::mat4 view = Assisi::Runtime::ViewMatrix(*camTransform);
+    const auto     *camTransform = _cameraScene.Get<Assisi::Runtime::TransformComponent>(_cameraEntity);
+    const glm::mat4 view         = Assisi::Runtime::ViewMatrix(*camTransform);
 
     _lighting.Update(*_scene, view);
 
@@ -234,9 +304,12 @@ void SandboxApp::OnRender()
     Assisi::Runtime::DrawScene(*_scene, view, _projection, _shader);
 }
 
-void SandboxApp::OnImGui()
+// ---------------------------------------------------------------------------
+// ImGui panels
+// ---------------------------------------------------------------------------
+
+void SandboxApp::DrawDiagnosticsWindow()
 {
-    // ── Diagnostics ─────────────────────────────────────────────────────────
     ImGui::Begin("Diagnostics");
     ImGui::Text("FPS: %d", GetFps());
     ImGui::Text("Sleep resolution: %.2f ms", GetSleepResolutionMs());
@@ -244,8 +317,10 @@ void SandboxApp::OnImGui()
     ImGui::TextDisabled("RMB: look  |  WASD: move  |  Space/Ctrl: up/down");
     ImGui::TextDisabled("Scroll: FOV  |  LMB: select  |  Esc: quit");
     ImGui::End();
+}
 
-    // ── Level Loader ────────────────────────────────────────────────────────
+void SandboxApp::DrawLevelsWindow()
+{
     ImGui::Begin("Levels");
 
     if (ImGui::Button("Refresh"))
@@ -270,7 +345,9 @@ void SandboxApp::OnImGui()
             }
             ImGui::EndCombo();
         }
-        const float halfW = (ImGui::GetContentRegionAvail().x - ImGui::GetStyle().ItemSpacing.x) * 0.5f;
+
+        const float halfW =
+            (ImGui::GetContentRegionAvail().x - ImGui::GetStyle().ItemSpacing.x) * 0.5f;
         if (ImGui::Button("Load", ImVec2(halfW, 0.0f)))
             LoadLevel(_levelFiles[_selectedLevel]);
         ImGui::SameLine();
@@ -287,157 +364,137 @@ void SandboxApp::OnImGui()
     {
         SaveLevel(_saveAsName);
         ScanLevels();
-        // Select the newly created file in the dropdown.
         const std::string newName(_saveAsName);
-        const auto it = std::find(_levelFiles.begin(), _levelFiles.end(), newName);
+        const auto        it = std::find(_levelFiles.begin(), _levelFiles.end(), newName);
         if (it != _levelFiles.end())
             _selectedLevel = static_cast<int>(std::distance(_levelFiles.begin(), it));
     }
 
     ImGui::End();
+}
 
+void SandboxApp::OnImGui()
+{
+    DrawDiagnosticsWindow();
+    DrawLevelsWindow();
     DrawInspector();
 }
 
-void SandboxApp::ScanLevels()
-{
-    _levelFiles.clear();
-    const auto resolved = Assisi::Core::AssetSystem::Resolve("levels");
-    if (!resolved)
-        return;
-
-    for (const auto &entry : std::filesystem::directory_iterator(*resolved))
-    {
-        if (entry.is_regular_file() && entry.path().extension() == ".alvl")
-            _levelFiles.push_back(entry.path().stem().string());
-    }
-    std::sort(_levelFiles.begin(), _levelFiles.end());
-    _selectedLevel = 0;
-}
-
-void SandboxApp::SaveLevel(const std::string &name)
-{
-    const auto resolved = Assisi::Core::AssetSystem::Resolve("levels/" + name + ".alvl");
-    if (!resolved)
-    {
-        Assisi::Core::Log::Error("SaveLevel: cannot resolve path for '{}'", name);
-        return;
-    }
-    Assisi::Runtime::SceneSerializer::SaveToFile(*_scene, *resolved);
-}
-
-void SandboxApp::LoadLevel(const std::string &name)
-{
-    if (!Assisi::Runtime::SceneSerializer::LoadFromFile(*_scene, "levels/" + name + ".alvl"))
-        return;
-
-    _selectedEntity = Assisi::ECS::NullEntity;
-    _physics.Clear();
-
-    // MeshRendererComponent::mesh is transient — re-bind after load.
-    for (auto [e, mrc] : _scene->Query<Assisi::Runtime::MeshRendererComponent>())
-        mrc.mesh = &_cubeMesh;
-
-    // Create Jolt bodies for entities that have a RigidBodyDescriptor.
-    for (auto [e, tc, desc] : _scene->Query<Assisi::Runtime::TransformComponent,
-                                             Assisi::Physics::RigidBodyDescriptor>())
-    {
-        const auto motion = desc.isStatic ? Assisi::Physics::BodyMotion::Static
-                                          : Assisi::Physics::BodyMotion::Dynamic;
-        (void)_scene->Add<Assisi::Physics::RigidBodyComponent>(
-            e, _physics.AddBox(tc.position, tc.rotation, desc.halfExtents, motion));
-    }
-}
-
 // ---------------------------------------------------------------------------
-// Helpers
+// Inspector
 // ---------------------------------------------------------------------------
 
-namespace
+bool SandboxApp::EditComponentFields(void *mut, const Assisi::Core::Reflect::ComponentMeta &meta)
 {
+    using namespace Assisi::Core::Reflect;
 
-/// @brief Ray vs OBB intersection using the slab method in local space.
-/// @param model  Model matrix of the OBB (unit cube [-0.5, 0.5] locally).
-/// @param tOut   Distance along the ray to the intersection (valid when true).
-bool RayOBBIntersect(glm::vec3 origin, glm::vec3 dir, const glm::mat4 &model, float &tOut)
-{
-    const glm::mat4 inv    = glm::inverse(model);
-    const glm::vec3 lOrig  = glm::vec3(inv * glm::vec4(origin, 1.f));
-    const glm::vec3 lDir   = glm::vec3(inv * glm::vec4(dir, 0.f));
+    bool anyEditable   = false;
+    bool anyFieldEdited = false;
 
-    float tMin = -std::numeric_limits<float>::max();
-    float tMax =  std::numeric_limits<float>::max();
-
-    for (int i = 0; i < 3; ++i)
+    for (const auto &field : meta.fields)
     {
-        if (std::abs(lDir[i]) < 1e-8f)
+        if (field.transient)
+            continue;
+        anyEditable = true;
+
+        void *fp = static_cast<char *>(mut) + field.offset;
+        ImGui::PushID(field.name.c_str());
+
+        bool edited = false;
+        switch (field.type)
         {
-            if (lOrig[i] < -0.5f || lOrig[i] > 0.5f)
-                return false;
+        case FieldType::Float:
+            edited = ImGui::DragFloat(field.name.c_str(), static_cast<float *>(fp), 0.01f);
+            break;
+        case FieldType::Double:
+            edited = ImGui::InputDouble(field.name.c_str(), static_cast<double *>(fp));
+            break;
+        case FieldType::Int:
+        case FieldType::Int32:
+            edited = ImGui::DragInt(field.name.c_str(), static_cast<int *>(fp));
+            break;
+        case FieldType::UInt32:
+            edited = ImGui::DragScalar(field.name.c_str(), ImGuiDataType_U32, fp, 1.f);
+            break;
+        case FieldType::Bool:
+            edited = ImGui::Checkbox(field.name.c_str(), static_cast<bool *>(fp));
+            break;
+        case FieldType::Vec2:
+            edited = ImGui::DragFloat2(field.name.c_str(), static_cast<float *>(fp), 0.01f);
+            break;
+        case FieldType::Vec3:
+            edited = ImGui::DragFloat3(field.name.c_str(), static_cast<float *>(fp), 0.01f);
+            break;
+        case FieldType::Vec4:
+            edited = ImGui::DragFloat4(field.name.c_str(), static_cast<float *>(fp), 0.01f);
+            break;
+        case FieldType::Quat:
+        {
+            auto     *quat  = static_cast<glm::quat *>(fp);
+            glm::vec3 euler = glm::degrees(glm::eulerAngles(*quat));
+            if (ImGui::DragFloat3(field.name.c_str(), &euler.x, 0.5f))
+            {
+                *quat  = glm::normalize(glm::quat(glm::radians(euler)));
+                edited = true;
+            }
+            break;
         }
-        else
-        {
-            float t1 = (-0.5f - lOrig[i]) / lDir[i];
-            float t2 = ( 0.5f - lOrig[i]) / lDir[i];
-            if (t1 > t2)
-                std::swap(t1, t2);
-            tMin = std::max(tMin, t1);
-            tMax = std::min(tMax, t2);
-            if (tMin > tMax)
-                return false;
+        default:
+            ImGui::TextDisabled("%s: [unsupported type]", field.name.c_str());
+            break;
         }
+
+        anyFieldEdited |= edited;
+        ImGui::PopID();
     }
 
-    if (tMax < 0.f)
-        return false;
+    if (!anyEditable)
+        ImGui::TextDisabled("(runtime-only)");
 
-    tOut = tMin > 0.f ? tMin : tMax;
-    return true;
+    return anyFieldEdited;
 }
 
-} // namespace
-
-// ---------------------------------------------------------------------------
-
-Assisi::ECS::Entity SandboxApp::PickEntity(glm::vec2 mousePos)
+void SandboxApp::HandlePhysicsEditing(bool anyFieldEdited)
 {
-    if (!_scene)
-        return Assisi::ECS::NullEntity;
-
-    const auto *camTransform = _cameraScene.Get<Assisi::Runtime::TransformComponent>(_cameraEntity);
-    const glm::mat4 view     = Assisi::Runtime::ViewMatrix(*camTransform);
-    const auto      fbSize   = GetWindow().GetFramebufferSize();
-    const float     w        = static_cast<float>(fbSize.Width);
-    const float     h        = static_cast<float>(fbSize.Height);
-
-    // NDC click position → view-space direction → world-space ray direction
-    const float     ndcX    = (2.f * mousePos.x / w) - 1.f;
-    const float     ndcY    = 1.f - (2.f * mousePos.y / h);
-    glm::vec4       viewDir = glm::inverse(_projection) * glm::vec4(ndcX, ndcY, -1.f, 1.f);
-    viewDir.z = -1.f;
-    viewDir.w =  0.f;
-    const glm::vec3 rayDir    = glm::normalize(glm::vec3(glm::inverse(view) * viewDir));
-    const glm::vec3 rayOrigin = camTransform->position;
-
-    float               closestT = std::numeric_limits<float>::max();
-    Assisi::ECS::Entity result   = Assisi::ECS::NullEntity;
-
-    for (auto [e, tc] : _scene->Query<Assisi::Runtime::TransformComponent>())
+    if (anyFieldEdited)
     {
-        const glm::mat4 model = tc.worldMatrix;
+        const auto *tc  = _scene->Get<Assisi::Runtime::TransformComponent>(_selectedEntity);
+        const auto *rbc = _scene->Get<Assisi::Physics::RigidBodyComponent>(_selectedEntity);
+        if (tc && rbc)
+            _physics.SetBodyTransform(*rbc, tc->position, tc->rotation);
+    }
 
-        float t = 0.f;
-        if (RayOBBIntersect(rayOrigin, rayDir, model, t) && t < closestT)
+    const bool nowDragging = ImGui::IsAnyItemActive();
+    if (nowDragging != _wasDragging)
+    {
+        const auto *rbc =
+            (_selectedEntity != Assisi::ECS::NullEntity && _scene->IsAlive(_selectedEntity))
+                ? _scene->Get<Assisi::Physics::RigidBodyComponent>(_selectedEntity)
+                : nullptr;
+
+        if (rbc)
         {
-            closestT = t;
-            result   = e;
+            if (nowDragging)
+            {
+                _physics.SetBodyMotionType(*rbc, Assisi::Physics::BodyMotion::Static);
+            }
+            else
+            {
+                const auto *desc     = _scene->Get<Assisi::Physics::RigidBodyDescriptor>(_selectedEntity);
+                const bool  isStatic = desc && desc->isStatic;
+                _physics.SetBodyMotionType(*rbc, isStatic ? Assisi::Physics::BodyMotion::Static
+                                                          : Assisi::Physics::BodyMotion::Dynamic);
+                if (!isStatic)
+                {
+                    const auto *tc = _scene->Get<Assisi::Runtime::TransformComponent>(_selectedEntity);
+                    if (tc)
+                        _physics.SetBodyTransform(*rbc, tc->position, tc->rotation);
+                }
+            }
         }
     }
-
-    return result;
+    _wasDragging = nowDragging;
 }
-
-// ---------------------------------------------------------------------------
 
 void SandboxApp::DrawInspector()
 {
@@ -480,117 +537,144 @@ void SandboxApp::DrawInspector()
             continue;
 
         ImGui::PushID(meta.name.c_str());
-        void *mut = const_cast<void *>(compPtr);
-
-        bool anyEditable = false;
-        for (const auto &field : meta.fields)
-        {
-            if (field.transient)
-                continue;
-            anyEditable = true;
-
-            void *fp = static_cast<char *>(mut) + field.offset;
-            ImGui::PushID(field.name.c_str());
-
-            bool edited = false;
-            switch (field.type)
-            {
-                case FieldType::Float:
-                    edited = ImGui::DragFloat(field.name.c_str(), static_cast<float *>(fp), 0.01f);
-                    break;
-                case FieldType::Double:
-                    edited = ImGui::InputDouble(field.name.c_str(), static_cast<double *>(fp));
-                    break;
-                case FieldType::Int:
-                case FieldType::Int32:
-                    edited = ImGui::DragInt(field.name.c_str(), static_cast<int *>(fp));
-                    break;
-                case FieldType::UInt32:
-                    edited = ImGui::DragScalar(field.name.c_str(), ImGuiDataType_U32, fp, 1.f);
-                    break;
-                case FieldType::Bool:
-                    edited = ImGui::Checkbox(field.name.c_str(), static_cast<bool *>(fp));
-                    break;
-                case FieldType::Vec2:
-                    edited = ImGui::DragFloat2(field.name.c_str(), static_cast<float *>(fp), 0.01f);
-                    break;
-                case FieldType::Vec3:
-                    edited = ImGui::DragFloat3(field.name.c_str(), static_cast<float *>(fp), 0.01f);
-                    break;
-                case FieldType::Vec4:
-                    edited = ImGui::DragFloat4(field.name.c_str(), static_cast<float *>(fp), 0.01f);
-                    break;
-                case FieldType::Quat:
-                {
-                    auto     *quat  = static_cast<glm::quat *>(fp);
-                    glm::vec3 euler = glm::degrees(glm::eulerAngles(*quat));
-                    if (ImGui::DragFloat3(field.name.c_str(), &euler.x, 0.5f))
-                    {
-                        *quat  = glm::normalize(glm::quat(glm::radians(euler)));
-                        edited = true;
-                    }
-                    break;
-                }
-                default:
-                    ImGui::TextDisabled("%s: [unsupported type]", field.name.c_str());
-                    break;
-            }
-            anyFieldEdited |= edited;
-
-            ImGui::PopID();
-        }
-
-        if (!anyEditable)
-            ImGui::TextDisabled("(runtime-only)");
-
+        anyFieldEdited |= EditComponentFields(const_cast<void *>(compPtr), meta);
         ImGui::PopID();
     }
 
+    HandlePhysicsEditing(anyFieldEdited);
     ImGui::End();
+}
 
-    // Push edited transform into the Jolt body whenever a field changes.
-    if (anyFieldEdited)
+// ---------------------------------------------------------------------------
+// Level management
+// ---------------------------------------------------------------------------
+
+void SandboxApp::ScanLevels()
+{
+    _levelFiles.clear();
+    const auto resolved = Assisi::Core::AssetSystem::Resolve("levels");
+    if (!resolved)
+        return;
+
+    for (const auto &entry : std::filesystem::directory_iterator(*resolved))
     {
-        const auto *tc  = _scene->Get<Assisi::Runtime::TransformComponent>(_selectedEntity);
-        const auto *rbc = _scene->Get<Assisi::Physics::RigidBodyComponent>(_selectedEntity);
-        if (tc && rbc)
-            _physics.SetBodyTransform(*rbc, tc->position, tc->rotation);
+        if (entry.is_regular_file() && entry.path().extension() == ".alvl")
+            _levelFiles.push_back(entry.path().stem().string());
     }
+    std::sort(_levelFiles.begin(), _levelFiles.end());
+    _selectedLevel = 0;
+}
 
-    // Freeze / unfreeze the selected entity's physics body on drag start / end.
-    // All bodies are created with mAllowDynamicOrKinematic=true, so any body can
-    // be switched between Static and Dynamic at runtime.
-    const bool nowDragging = ImGui::IsAnyItemActive();
-    if (nowDragging != _wasDragging)
+void SandboxApp::SaveLevel(const std::string &name)
+{
+    const auto resolved = Assisi::Core::AssetSystem::Resolve("levels/" + name + ".alvl");
+    if (!resolved)
     {
-        const auto *rbc = (_selectedEntity != Assisi::ECS::NullEntity && _scene->IsAlive(_selectedEntity))
-                              ? _scene->Get<Assisi::Physics::RigidBodyComponent>(_selectedEntity)
-                              : nullptr;
-        if (rbc)
+        Assisi::Core::Log::Error("SaveLevel: cannot resolve path for '{}'", name);
+        return;
+    }
+    Assisi::Runtime::SceneSerializer::SaveToFile(*_scene, *resolved);
+}
+
+void SandboxApp::LoadLevel(const std::string &name)
+{
+    if (!Assisi::Runtime::SceneSerializer::LoadFromFile(*_scene, "levels/" + name + ".alvl"))
+        return;
+
+    _selectedEntity = Assisi::ECS::NullEntity;
+    _physics.Clear();
+
+    for (auto [e, mrc] : _scene->Query<Assisi::Runtime::MeshRendererComponent>())
+        mrc.mesh = &_cubeMesh;
+
+    for (auto [e, tc, desc] : _scene->Query<Assisi::Runtime::TransformComponent,
+                                             Assisi::Physics::RigidBodyDescriptor>())
+    {
+        const auto motion = desc.isStatic ? Assisi::Physics::BodyMotion::Static
+                                          : Assisi::Physics::BodyMotion::Dynamic;
+        (void)_scene->Add<Assisi::Physics::RigidBodyComponent>(
+            e, _physics.AddBox(tc.position, tc.rotation, desc.halfExtents, motion));
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Ray picking
+// ---------------------------------------------------------------------------
+
+namespace
+{
+
+bool RayOBBIntersect(glm::vec3 origin, glm::vec3 dir, const glm::mat4 &model, float &tOut)
+{
+    const glm::mat4 inv   = glm::inverse(model);
+    const glm::vec3 lOrig = glm::vec3(inv * glm::vec4(origin, 1.f));
+    const glm::vec3 lDir  = glm::vec3(inv * glm::vec4(dir, 0.f));
+
+    float tMin = -std::numeric_limits<float>::max();
+    float tMax =  std::numeric_limits<float>::max();
+
+    for (int i = 0; i < 3; ++i)
+    {
+        if (std::abs(lDir[i]) < 1e-8f)
         {
-            if (nowDragging)
-            {
-                // Freeze: switch to Static so Jolt won't apply forces while editing.
-                // If the body is already Static this is a no-op inside Jolt.
-                _physics.SetBodyMotionType(*rbc, Assisi::Physics::BodyMotion::Static);
-            }
-            else
-            {
-                // Restore: apply whatever isStatic says now (user may have changed it).
-                const auto *desc     = _scene->Get<Assisi::Physics::RigidBodyDescriptor>(_selectedEntity);
-                const bool  isStatic = desc && desc->isStatic;
-                _physics.SetBodyMotionType(*rbc, isStatic ? Assisi::Physics::BodyMotion::Static
-                                                          : Assisi::Physics::BodyMotion::Dynamic);
-                if (!isStatic)
-                {
-                    const auto *tc = _scene->Get<Assisi::Runtime::TransformComponent>(_selectedEntity);
-                    if (tc)
-                        _physics.SetBodyTransform(*rbc, tc->position, tc->rotation);
-                }
-            }
+            if (lOrig[i] < -0.5f || lOrig[i] > 0.5f)
+                return false;
+        }
+        else
+        {
+            float t1 = (-0.5f - lOrig[i]) / lDir[i];
+            float t2 = ( 0.5f - lOrig[i]) / lDir[i];
+            if (t1 > t2)
+                std::swap(t1, t2);
+            tMin = std::max(tMin, t1);
+            tMax = std::min(tMax, t2);
+            if (tMin > tMax)
+                return false;
         }
     }
-    _wasDragging = nowDragging;
+
+    if (tMax < 0.f)
+        return false;
+
+    tOut = tMin > 0.f ? tMin : tMax;
+    return true;
+}
+
+} // namespace
+
+Assisi::ECS::Entity SandboxApp::PickEntity(glm::vec2 mousePos)
+{
+    if (!_scene)
+        return Assisi::ECS::NullEntity;
+
+    const auto     *camTransform = _cameraScene.Get<Assisi::Runtime::TransformComponent>(_cameraEntity);
+    const glm::mat4 view         = Assisi::Runtime::ViewMatrix(*camTransform);
+    const auto      fbSize       = GetWindow().GetFramebufferSize();
+    const float     w            = static_cast<float>(fbSize.Width);
+    const float     h            = static_cast<float>(fbSize.Height);
+
+    const float     ndcX    = (2.f * mousePos.x / w) - 1.f;
+    const float     ndcY    = 1.f - (2.f * mousePos.y / h);
+    glm::vec4       viewDir = glm::inverse(_projection) * glm::vec4(ndcX, ndcY, -1.f, 1.f);
+    viewDir.z = -1.f;
+    viewDir.w =  0.f;
+    const glm::vec3 rayDir    = glm::normalize(glm::vec3(glm::inverse(view) * viewDir));
+    const glm::vec3 rayOrigin = camTransform->position;
+
+    float               closestT = std::numeric_limits<float>::max();
+    Assisi::ECS::Entity result   = Assisi::ECS::NullEntity;
+
+    for (auto [e, tc] : _scene->Query<Assisi::Runtime::TransformComponent>())
+    {
+        float t = 0.f;
+        if (RayOBBIntersect(rayOrigin, rayDir, tc.worldMatrix, t) && t < closestT)
+        {
+            closestT = t;
+            result   = e;
+        }
+    }
+
+    return result;
 }
 
 // ---------------------------------------------------------------------------

--- a/assets/levels/Test.alvl
+++ b/assets/levels/Test.alvl
@@ -90,21 +90,21 @@
         "PointLightComponent": {
           "color": [1.0, 1.0, 1.0],
           "intensity": 150.0,
-          "radius": 30.0
+          "radius": 8.0
         }
       }
     },
     {
       "components": {
         "TransformComponent": {
-          "position": [-5.0, 2.5, 0.0],
+          "position": [-1.0, 2.5, 0.0],
           "rotation": [1.0, 0.0, 0.0, 0.0],
           "scale": [1.0, 1.0, 1.0]
         },
         "PointLightComponent": {
           "color": [0.2, 0.4, 1.0],
           "intensity": 200.0,
-          "radius": 30.0
+          "radius": 50.0
         }
       }
     },

--- a/modules/App/CMakeLists.txt
+++ b/modules/App/CMakeLists.txt
@@ -5,11 +5,15 @@ target_sources(Assisi-App
   PUBLIC
     "include/Assisi/App/AppConfig.hpp"
     "include/Assisi/App/Application.hpp"
+    "include/Assisi/App/GameApplication.hpp"
     "include/Assisi/App/OptionsConfig.hpp"
+    "include/Assisi/App/SystemRegistry.hpp"
   PRIVATE
     "src/AppConfig.cpp"
     "src/Application.cpp"
+    "src/GameApplication.cpp"
     "src/OptionsConfig.cpp"
+    "src/SystemRegistry.cpp"
 )
 
 target_include_directories(Assisi-App

--- a/modules/App/include/Assisi/App/GameApplication.hpp
+++ b/modules/App/include/Assisi/App/GameApplication.hpp
@@ -1,0 +1,82 @@
+#pragma once
+
+/// @file App/GameApplication.hpp
+/// @brief Base class for games and the editor.
+///
+/// GameApplication sits between the thin Application base (window, loop, ImGui)
+/// and your game code.  It owns the scene, physics world, and system registry,
+/// and pre-wires a set of default systems so a new project works out of the box.
+///
+/// Pre-wired default systems:
+///   FixedUpdate: PhysicsStep → PhysicsSyncTransforms
+///   PostUpdate:  PropagateTransforms → CleanupDestroyTag
+///
+/// Override OnGameStart() to register your own systems and do one-time setup.
+/// Override OnGameRender() to submit draw calls (receives no automatic render
+/// context — build a RenderContext from your camera entity and call
+/// _systems.Run(SystemPhase::Render, ctx) yourself).
+///
+/// @par Minimal example
+/// @code
+/// class MyGame : public GameApplication
+/// {
+///     void OnGameStart() override
+///     {
+///         _systems.Register(SystemPhase::Update, "Movement", &MovementSystem);
+///         _systems.Register(SystemPhase::Render, "Draw",
+///             [this](RenderContext& ctx) {
+///                 Runtime::DrawScene(ctx.scene, ctx.view, ctx.projection, _shader);
+///             });
+///     }
+///
+///     void OnGameRender() override
+///     {
+///         const glm::mat4 view = Runtime::ViewMatrix(...);
+///         _systems.Run(SystemPhase::Render, { _scene, 0.f, view, _projection });
+///     }
+/// };
+/// @endcode
+
+#include <Assisi/App/Application.hpp>
+#include <Assisi/App/SystemRegistry.hpp>
+#include <Assisi/ECS/Scene.hpp>
+#include <Assisi/Physics/PhysicsWorld.hpp>
+
+namespace Assisi::App
+{
+
+class GameApplication : public Application
+{
+  public:
+    GameApplication()           = default;
+    ~GameApplication() override = default;
+
+    GameApplication(const GameApplication &)            = delete;
+    GameApplication &operator=(const GameApplication &) = delete;
+
+  protected:
+    /// @brief Called after default systems are registered.  Register your own
+    ///        systems and perform one-time game setup here.
+    virtual void OnGameStart() {}
+
+    /// @brief Called after all system phases (PreUpdate/Update/PostUpdate) have run.
+    ///        Override to submit render commands or call
+    ///        _systems.Run(SystemPhase::Render, ctx).
+    virtual void OnGameRender() {}
+
+    /// @brief Called after the main loop exits, before Application teardown.
+    virtual void OnGameShutdown() {}
+
+    ECS::Scene              _scene;
+    Physics::PhysicsWorld   _physics;
+    SystemRegistry          _systems;
+
+  private:
+    void OnStart()           final;
+    void OnFixedUpdate(float dt) final;
+    void OnUpdate(float dt)      final;
+    void OnRender()              final;
+    void OnShutdown()            final;
+};
+
+} // namespace Assisi::App

--- a/modules/App/include/Assisi/App/SystemRegistry.hpp
+++ b/modules/App/include/Assisi/App/SystemRegistry.hpp
@@ -1,0 +1,163 @@
+#pragma once
+
+/// @file App/SystemRegistry.hpp
+/// @brief Ordered per-phase system registry with dependency-based scheduling.
+///
+/// Two context types exist depending on the phase:
+///   - SystemContext  — game logic phases (PreUpdate, FixedUpdate, Update, PostUpdate)
+///   - RenderContext  — render phase only (adds view/projection matrices)
+///
+/// @par Example
+/// @code
+/// // Game logic system
+/// _systems.Register(SystemPhase::Update, "Damage", &DamageSystem)
+///         .After("Physics");
+///
+/// // Render system — needs view/projection
+/// _systems.Register(SystemPhase::Render, "DrawScene",
+///     [this](RenderContext& ctx) {
+///         Runtime::DrawScene(ctx.scene, ctx.view, ctx.projection, _shader);
+///     });
+///
+/// // Dispatch
+/// _systems.Run(SystemPhase::Update,  { *_scene, dt,  GetInput() });
+/// _systems.Run(SystemPhase::Render,  { *_scene, 0.f, view, proj });
+/// @endcode
+///
+/// Systems run in dependency order within each phase.
+/// Systems with no ordering relationship run in registration order.
+
+#include <Assisi/ECS/Scene.hpp>
+#include <Assisi/Math/GLM.hpp>
+#include <Assisi/Window/InputContext.hpp>
+
+#include <array>
+#include <cstddef>
+#include <functional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace Assisi::App
+{
+
+/// @brief Passed to game logic systems (PreUpdate, FixedUpdate, Update, PostUpdate).
+struct SystemContext
+{
+    ECS::Scene           &scene;
+    float                 dt;
+    Window::InputContext &input;
+};
+
+/// @brief Passed to render systems (Render phase only).
+struct RenderContext
+{
+    ECS::Scene  &scene;
+    float        dt;
+    glm::mat4    view;
+    glm::mat4    projection;
+};
+
+/// @brief Execution phase that determines when a system runs and which context it receives.
+enum class SystemPhase
+{
+    PreUpdate   = 0, ///< After input is polled; before physics and game logic.
+    FixedUpdate = 1, ///< Fixed timestep; may run multiple times per render frame.
+    Update      = 2, ///< Once per render frame; main game logic.
+    PostUpdate  = 3, ///< After game logic; transform propagation and cleanup.
+    Render      = 4, ///< Camera, culling, draw calls.  Uses RenderContext.
+    _Count
+};
+
+/// @brief Stores and dispatches system functions grouped by phase.
+///
+/// Builds an execution order from After()/Before() constraints on first Run()
+/// and caches it.  The cache is invalidated automatically when new systems
+/// are registered.
+class SystemRegistry
+{
+  public:
+    /// @brief Fluent handle for chaining ordering constraints after Register().
+    class SystemHandle
+    {
+      public:
+        /// @brief This system runs after the named system within the same phase.
+        SystemHandle &After(std::string_view name);
+
+        /// @brief This system runs before the named system within the same phase.
+        SystemHandle &Before(std::string_view name);
+
+      private:
+        friend class SystemRegistry;
+
+        SystemHandle(SystemRegistry *registry, bool isRender, std::size_t phaseIndex,
+                     std::size_t entryIndex)
+            : _registry(registry)
+            , _isRender(isRender)
+            , _phaseIndex(phaseIndex)
+            , _entryIndex(entryIndex)
+        {
+        }
+
+        SystemRegistry *_registry;
+        bool            _isRender;
+        std::size_t     _phaseIndex; ///< Unused when _isRender == true.
+        std::size_t     _entryIndex; ///< Index into the entry vector — stable across push_backs.
+    };
+
+    /// @brief Register a game logic system for a non-Render phase.
+    SystemHandle Register(SystemPhase                          phase,
+                          std::string_view                     name,
+                          std::function<void(SystemContext &)> fn);
+
+    /// @brief Register a render system.  @p phase must be SystemPhase::Render.
+    SystemHandle Register(SystemPhase                          phase,
+                          std::string_view                     name,
+                          std::function<void(RenderContext &)> fn);
+
+    /// @brief Run all game logic systems for the given phase in dependency order.
+    void Run(SystemPhase phase, SystemContext ctx);
+
+    /// @brief Run all render systems in dependency order.  @p phase must be SystemPhase::Render.
+    void Run(SystemPhase phase, RenderContext ctx);
+
+  private:
+    struct GameEntry
+    {
+        std::string                        name;
+        std::function<void(SystemContext &)> fn;
+        std::vector<std::string>           after;
+        std::vector<std::string>           before;
+    };
+
+    struct RenderEntry
+    {
+        std::string                        name;
+        std::function<void(RenderContext &)> fn;
+        std::vector<std::string>           after;
+        std::vector<std::string>           before;
+    };
+
+    /// Number of game-logic phases (everything except Render).
+    static constexpr std::size_t kGamePhaseCount = static_cast<std::size_t>(SystemPhase::Render);
+
+    static std::size_t Index(SystemPhase phase) { return static_cast<std::size_t>(phase); }
+
+    /// @brief Topological sort (Kahn's algorithm) over any entry type with name/after/before.
+    template <typename Entry>
+    static std::vector<std::size_t> TopoSort(const std::vector<Entry> &entries,
+                                             std::string_view          phaseName);
+
+    void SortPhase(std::size_t phaseIndex);
+    void SortRender();
+
+    std::array<std::vector<GameEntry>, kGamePhaseCount>  _entries;
+    std::array<std::vector<std::size_t>, kGamePhaseCount> _sorted;
+    std::array<bool, kGamePhaseCount>                     _dirty{};
+
+    std::vector<RenderEntry>  _renderEntries;
+    std::vector<std::size_t>  _renderSorted;
+    bool                      _renderDirty = false;
+};
+
+} // namespace Assisi::App

--- a/modules/App/src/Application.cpp
+++ b/modules/App/src/Application.cpp
@@ -16,6 +16,7 @@
 // --- Engine headers ---------------------------------------------------------
 #include <Assisi/App/Application.hpp>
 #include <Assisi/Core/AssetSystem.hpp>
+#include <Assisi/Core/EventQueue.hpp>
 #include <Assisi/Core/Logger.hpp>
 #include <Assisi/Core/Sinks.hpp>
 #include <Assisi/Debug/DebugUI.hpp>
@@ -271,6 +272,7 @@ void Application::Run()
         }
 
         RenderFrame();
+        Core::EventQueue::Instance().Flush();
     }
 
     OnShutdown();

--- a/modules/App/src/GameApplication.cpp
+++ b/modules/App/src/GameApplication.cpp
@@ -1,0 +1,55 @@
+/// @file GameApplication.cpp
+
+#include <Assisi/App/GameApplication.hpp>
+#include <Assisi/Runtime/Hierarchy.hpp>
+#include <Assisi/Runtime/Lifecycle.hpp>
+
+namespace Assisi::App
+{
+
+void GameApplication::OnStart()
+{
+    // --- Default FixedUpdate systems ---
+
+    _systems.Register(SystemPhase::FixedUpdate, "PhysicsStep",
+                      [this](SystemContext &ctx) { _physics.Update(ctx.dt); });
+
+    _systems.Register(SystemPhase::FixedUpdate, "PhysicsSyncTransforms",
+                      [this](SystemContext &ctx) { _physics.SyncTransforms(ctx.scene); })
+        .After("PhysicsStep");
+
+    // --- Default PostUpdate systems ---
+
+    _systems.Register(SystemPhase::PostUpdate, "PropagateTransforms",
+                      [](SystemContext &ctx) { Runtime::PropagateTransforms(ctx.scene); });
+
+    _systems.Register(SystemPhase::PostUpdate, "CleanupDestroyTag",
+                      [](SystemContext &ctx) { Runtime::DestroyMarked(ctx.scene); })
+        .After("PropagateTransforms");
+
+    OnGameStart();
+}
+
+void GameApplication::OnFixedUpdate(float dt)
+{
+    _systems.Run(SystemPhase::FixedUpdate, {_scene, dt, GetInput()});
+}
+
+void GameApplication::OnUpdate(float dt)
+{
+    _systems.Run(SystemPhase::PreUpdate,  {_scene, dt, GetInput()});
+    _systems.Run(SystemPhase::Update,     {_scene, dt, GetInput()});
+    _systems.Run(SystemPhase::PostUpdate, {_scene, dt, GetInput()});
+}
+
+void GameApplication::OnRender()
+{
+    OnGameRender();
+}
+
+void GameApplication::OnShutdown()
+{
+    OnGameShutdown();
+}
+
+} // namespace Assisi::App

--- a/modules/App/src/SystemRegistry.cpp
+++ b/modules/App/src/SystemRegistry.cpp
@@ -1,0 +1,217 @@
+/// @file SystemRegistry.cpp
+
+#include <Assisi/App/SystemRegistry.hpp>
+#include <Assisi/Core/Logger.hpp>
+
+#include <set>
+#include <unordered_map>
+
+namespace Assisi::App
+{
+
+// ---------------------------------------------------------------------------
+// TopoSort — shared by game and render phases
+// ---------------------------------------------------------------------------
+
+template <typename Entry>
+std::vector<std::size_t> SystemRegistry::TopoSort(const std::vector<Entry> &entries,
+                                                   std::string_view          phaseName)
+{
+    const std::size_t n = entries.size();
+
+    std::vector<std::size_t> sorted;
+    sorted.reserve(n);
+
+    if (n == 0)
+        return sorted;
+
+    // name → index
+    std::unordered_map<std::string, std::size_t> nameToIndex;
+    nameToIndex.reserve(n);
+    for (std::size_t i = 0; i < n; ++i)
+        nameToIndex.emplace(entries[i].name, i);
+
+    // Build adjacency list and in-degree counts.
+    // Edge from→to: 'from' executes before 'to'.
+    std::vector<std::vector<std::size_t>> adj(n);
+    std::vector<int>                      inDegree(n, 0);
+
+    // Deduplicate edges so A.Before("B") + B.After("A") doesn't double-count.
+    std::set<std::pair<std::size_t, std::size_t>> seen;
+
+    auto addEdge = [&](std::size_t from, std::size_t to)
+    {
+        if (seen.insert({from, to}).second)
+        {
+            adj[from].push_back(to);
+            ++inDegree[to];
+        }
+    };
+
+    for (std::size_t i = 0; i < n; ++i)
+    {
+        for (const auto &dep : entries[i].after)
+        {
+            auto it = nameToIndex.find(dep);
+            if (it == nameToIndex.end())
+            {
+                Core::Log::Error(
+                    "SystemRegistry({}): '{}' declares After(\"{}\") but \"{}\" is not registered.",
+                    phaseName, entries[i].name, dep, dep);
+                continue;
+            }
+            addEdge(it->second, i);
+        }
+
+        for (const auto &dep : entries[i].before)
+        {
+            auto it = nameToIndex.find(dep);
+            if (it == nameToIndex.end())
+            {
+                Core::Log::Error(
+                    "SystemRegistry({}): '{}' declares Before(\"{}\") but \"{}\" is not registered.",
+                    phaseName, entries[i].name, dep, dep);
+                continue;
+            }
+            addEdge(i, it->second);
+        }
+    }
+
+    // Kahn's algorithm.
+    // Iterating by index preserves registration order within each "layer",
+    // giving deterministic output without extra sorting.
+    std::vector<std::size_t> ready;
+    ready.reserve(n);
+    for (std::size_t i = 0; i < n; ++i)
+        if (inDegree[i] == 0)
+            ready.push_back(i);
+
+    std::size_t head = 0;
+    while (head < ready.size())
+    {
+        const std::size_t curr = ready[head++];
+        sorted.push_back(curr);
+        for (std::size_t next : adj[curr])
+            if (--inDegree[next] == 0)
+                ready.push_back(next);
+    }
+
+    if (sorted.size() != n)
+    {
+        Core::Log::Fatal(
+            "SystemRegistry({}): cycle detected. Check After()/Before() declarations.", phaseName);
+        sorted.clear();
+    }
+
+    return sorted;
+}
+
+// Explicit instantiations — keeps the template definition out of the header.
+template std::vector<std::size_t>
+SystemRegistry::TopoSort<SystemRegistry::GameEntry>(const std::vector<GameEntry> &,
+                                                     std::string_view);
+template std::vector<std::size_t>
+SystemRegistry::TopoSort<SystemRegistry::RenderEntry>(const std::vector<RenderEntry> &,
+                                                       std::string_view);
+
+// ---------------------------------------------------------------------------
+// SystemHandle
+// ---------------------------------------------------------------------------
+
+SystemRegistry::SystemHandle &SystemRegistry::SystemHandle::After(std::string_view name)
+{
+    if (_isRender)
+    {
+        _registry->_renderEntries[_entryIndex].after.emplace_back(name);
+        _registry->_renderDirty = true;
+    }
+    else
+    {
+        _registry->_entries[_phaseIndex][_entryIndex].after.emplace_back(name);
+        _registry->_dirty[_phaseIndex] = true;
+    }
+    return *this;
+}
+
+SystemRegistry::SystemHandle &SystemRegistry::SystemHandle::Before(std::string_view name)
+{
+    if (_isRender)
+    {
+        _registry->_renderEntries[_entryIndex].before.emplace_back(name);
+        _registry->_renderDirty = true;
+    }
+    else
+    {
+        _registry->_entries[_phaseIndex][_entryIndex].before.emplace_back(name);
+        _registry->_dirty[_phaseIndex] = true;
+    }
+    return *this;
+}
+
+// ---------------------------------------------------------------------------
+// Register
+// ---------------------------------------------------------------------------
+
+SystemRegistry::SystemHandle SystemRegistry::Register(SystemPhase                          phase,
+                                                       std::string_view                     name,
+                                                       std::function<void(SystemContext &)> fn)
+{
+    const std::size_t pi = Index(phase);
+    const std::size_t ei = _entries[pi].size();
+    _entries[pi].push_back({std::string(name), std::move(fn), {}, {}});
+    _dirty[pi] = true;
+    return SystemHandle(this, /*isRender=*/false, pi, ei);
+}
+
+SystemRegistry::SystemHandle SystemRegistry::Register(SystemPhase                          phase,
+                                                       std::string_view                     name,
+                                                       std::function<void(RenderContext &)> fn)
+{
+    const std::size_t ei = _renderEntries.size();
+    _renderEntries.push_back({std::string(name), std::move(fn), {}, {}});
+    _renderDirty = true;
+    return SystemHandle(this, /*isRender=*/true, /*phaseIndex=*/0, ei);
+}
+
+// ---------------------------------------------------------------------------
+// Run
+// ---------------------------------------------------------------------------
+
+void SystemRegistry::Run(SystemPhase phase, SystemContext ctx)
+{
+    const std::size_t pi = Index(phase);
+    if (_dirty[pi])
+        SortPhase(pi);
+
+    for (std::size_t i : _sorted[pi])
+        _entries[pi][i].fn(ctx);
+}
+
+void SystemRegistry::Run(SystemPhase, RenderContext ctx)
+{
+    if (_renderDirty)
+        SortRender();
+
+    for (std::size_t i : _renderSorted)
+        _renderEntries[i].fn(ctx);
+}
+
+// ---------------------------------------------------------------------------
+// Sort
+// ---------------------------------------------------------------------------
+
+void SystemRegistry::SortPhase(std::size_t pi)
+{
+    static constexpr std::string_view kNames[] = {"PreUpdate", "FixedUpdate", "Update",
+                                                   "PostUpdate"};
+    _sorted[pi]  = TopoSort(_entries[pi], kNames[pi]);
+    _dirty[pi]   = false;
+}
+
+void SystemRegistry::SortRender()
+{
+    _renderSorted = TopoSort(_renderEntries, "Render");
+    _renderDirty  = false;
+}
+
+} // namespace Assisi::App

--- a/modules/Core/CMakeLists.txt
+++ b/modules/Core/CMakeLists.txt
@@ -5,11 +5,13 @@ target_sources(Assisi-Core
   PRIVATE
     "src/AssetSystem.cpp"
     "src/ComponentRegistry.cpp"
+    "src/EventQueue.cpp"
     "src/Logger.cpp"
     "src/Sinks.cpp"
   PUBLIC
     "include/Assisi/Core/AssetSystem.hpp"
     "include/Assisi/Core/Errors.hpp"
+    "include/Assisi/Core/EventQueue.hpp"
     "include/Assisi/Core/Logger.hpp"
     "include/Assisi/Core/Sinks.hpp"
     "include/Assisi/Core/Reflect/Annotations.hpp"

--- a/modules/Core/include/Assisi/Core/EventQueue.hpp
+++ b/modules/Core/include/Assisi/Core/EventQueue.hpp
@@ -1,0 +1,126 @@
+#pragma once
+
+/// @file Core/EventQueue.hpp
+/// @brief Per-frame typed event queue.
+///
+/// Events are plain data structs written by producer systems and read by
+/// consumer systems within the same frame.  The Application flushes all
+/// queues once per render frame, so events do not persist across frames.
+///
+/// @par Frame ordering
+/// @code
+/// // One render frame:
+///
+///   glfwPollEvents()    ← GLFW dispatches window/input callbacks
+///   _input->Poll()      ← InputContext updated; input state is now fresh
+///
+///   OnFixedUpdate (may run N times):
+///     PhysicsStep     → Push(CollisionEvent{a, b})
+///     PhysicsSyncTransforms
+///
+///   OnUpdate:
+///     PreUpdate       → input is available; first chance to react this frame
+///     Update          → DamageSystem: Read<CollisionEvent>()  ← visible, same frame as FixedUpdate
+///     PostUpdate      → CleanupSystem: Read<DestroyRequestEvent>()  ← visible, pushed in Update
+///
+///   RenderFrame + OnImGui
+///     (events pushed here are NOT visible to systems this frame —
+///      they are flushed at end of frame before systems run again)
+///
+///   EventQueue::Flush()  ← all queues cleared
+/// @endcode
+///
+/// Rule of thumb: an event pushed in phase X is readable in any phase that
+/// runs AFTER X within the same frame, before Flush().
+///
+/// @par Example
+/// @code
+/// // Define an event (annotate with AEVENT() to mark intent)
+/// AEVENT()
+/// struct CollisionEvent { Entity a; Entity b; };
+///
+/// // Produce (e.g. from the physics system)
+/// EventQueue::Instance().Push(CollisionEvent{entityA, entityB});
+///
+/// // Consume (e.g. in a PostUpdate system)
+/// for (const auto& e : EventQueue::Instance().Read<CollisionEvent>())
+///     HandleCollision(e);
+/// @endcode
+///
+/// Flushing is handled automatically by Application::Run() at the end of
+/// each render frame.  Call Flush() manually in unit tests or custom loops.
+
+#include <memory>
+#include <span>
+#include <typeindex>
+#include <unordered_map>
+#include <vector>
+
+namespace Assisi::Core
+{
+
+/// @brief Global per-frame event queue.
+///
+/// Push events from any system; consume them with Read<E>() before the frame
+/// ends.  All queues are cleared by Flush() once per frame.
+class EventQueue
+{
+  public:
+    static EventQueue &Instance();
+
+    /// @brief Append an event of type E to its queue.
+    template <typename E>
+    void Push(E event)
+    {
+        GetOrCreate<E>().events.push_back(std::move(event));
+    }
+
+    /// @brief Returns a view over all events of type E queued this frame.
+    ///
+    /// The span is valid until the next Flush() call.
+    /// Returns an empty span if no events of this type were pushed.
+    template <typename E>
+    std::span<const E> Read() const
+    {
+        auto it = _queues.find(typeid(E));
+        if (it == _queues.end())
+            return {};
+        return static_cast<const TypedQueue<E> &>(*it->second).events;
+    }
+
+    /// @brief Clear all event queues.  Called by Application once per frame.
+    void Flush()
+    {
+        for (auto &[type, queue] : _queues)
+            queue->Clear();
+    }
+
+  private:
+    struct IQueue
+    {
+        virtual ~IQueue() = default;
+        virtual void Clear() = 0;
+    };
+
+    template <typename E>
+    struct TypedQueue : IQueue
+    {
+        std::vector<E> events;
+        void Clear() override { events.clear(); }
+    };
+
+    template <typename E>
+    TypedQueue<E> &GetOrCreate()
+    {
+        auto it = _queues.find(typeid(E));
+        if (it != _queues.end())
+            return static_cast<TypedQueue<E> &>(*it->second);
+
+        auto result = _queues.emplace(typeid(E), std::make_unique<TypedQueue<E>>());
+        return static_cast<TypedQueue<E> &>(*result.first->second);
+    }
+
+    std::unordered_map<std::type_index, std::unique_ptr<IQueue>> _queues;
+};
+
+} // namespace Assisi::Core

--- a/modules/Core/include/Assisi/Core/Reflect/Annotations.hpp
+++ b/modules/Core/include/Assisi/Core/Reflect/Annotations.hpp
@@ -14,3 +14,8 @@
 
 #define ACOMP(...)
 #define AFIELD(...)
+
+/// AEVENT() — marks a struct as an event type.
+/// Compiles to nothing today; reserved for future reflectgen support
+/// (serialization, network replication interception).
+#define AEVENT(...)

--- a/modules/Core/src/EventQueue.cpp
+++ b/modules/Core/src/EventQueue.cpp
@@ -1,0 +1,14 @@
+/// @file EventQueue.cpp
+
+#include <Assisi/Core/EventQueue.hpp>
+
+namespace Assisi::Core
+{
+
+EventQueue &EventQueue::Instance()
+{
+    static EventQueue instance;
+    return instance;
+}
+
+} // namespace Assisi::Core

--- a/modules/Runtime/CMakeLists.txt
+++ b/modules/Runtime/CMakeLists.txt
@@ -8,6 +8,7 @@ target_sources(Assisi-Runtime
     "include/Assisi/Runtime/Hierarchy.hpp"
     "include/Assisi/Runtime/LightComponents.hpp"
     "include/Assisi/Runtime/LightingSystem.hpp"
+    "include/Assisi/Runtime/Lifecycle.hpp"
     "include/Assisi/Runtime/Renderer.hpp"
     "include/Assisi/Runtime/SceneSerializer.hpp"
     "include/Assisi/Runtime/Transform.hpp"

--- a/modules/Runtime/include/Assisi/Runtime/Lifecycle.hpp
+++ b/modules/Runtime/include/Assisi/Runtime/Lifecycle.hpp
@@ -1,0 +1,44 @@
+#pragma once
+
+/// @file Runtime/Lifecycle.hpp
+/// @brief Entity lifecycle utilities.
+///
+/// Add DestroyTag to an entity to have it destroyed at the end of PostUpdate
+/// by the default CleanupDestroyTag system registered in GameApplication.
+///
+/// @code
+/// scene.Add<DestroyTag>(entity);  // entity is gone next PostUpdate
+/// @endcode
+
+#include <Assisi/ECS/Scene.hpp>
+#include <Assisi/Prelude.hpp>
+
+#include <vector>
+
+namespace Assisi::Runtime
+{
+
+/// @brief Marker component — entity is destroyed at end of PostUpdate.
+///
+/// No data.  Presence on an entity is the signal; the value is irrelevant.
+struct DestroyTag
+{
+};
+
+/// @brief Destroy all entities that carry DestroyTag.
+///
+/// Called automatically by GameApplication's CleanupDestroyTag system.
+/// Can also be called manually in custom loops or unit tests.
+inline void DestroyMarked(ECS::Scene &scene)
+{
+    std::vector<ECS::Entity> dying;
+    for (auto [e, tag] : scene.Query<DestroyTag>())
+    {
+        (void)tag;
+        dying.push_back(e);
+    }
+    for (ECS::Entity e : dying)
+        scene.Destroy(e);
+}
+
+} // namespace Assisi::Runtime


### PR DESCRIPTION
- Core: EventQueue — per-frame typed event queue with Push<E>/Read<E>/Flush; flushed by Application::Run() at end of each frame. Adds AEVENT() annotation macro to Annotations.hpp.
- App: SystemRegistry — dependency-ordered system dispatcher across five phases (PreUpdate, FixedUpdate, Update, PostUpdate, Render). Supports After()/Before() ordering constraints resolved via Kahn's topological sort, cached per phase.
- App: GameApplication — Application subclass that owns Scene, PhysicsWorld, and SystemRegistry, pre-wiring PhysicsStep, PhysicsSyncTransforms, PropagateTransforms, and CleanupDestroyTag. Override OnGameStart()/OnGameRender().
- Runtime: Lifecycle.hpp — DestroyTag marker component and DestroyMarked() free function for deferred entity destruction at end of PostUpdate.
- Sandbox updated to derive from GameApplication.