### PR TITLE
Converted ImGUI to docking branch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.23)
+cmake_minimum_required(VERSION 3.28)
 
 project(Assisi
   VERSION 0.1.0
@@ -159,17 +159,31 @@ find_package(stb CONFIG REQUIRED)
 find_package(glad CONFIG REQUIRED)
 find_package(assimp CONFIG REQUIRED)
 find_package(Jolt CONFIG REQUIRED)
-find_package(imgui CONFIG REQUIRED)
 find_package(nlohmann_json CONFIG REQUIRED)
 
-# Derive the imgui package root (needed to compile backend source files from res/bindings/).
-if(DEFINED imgui_PACKAGE_FOLDER_DEBUG)
-    set(ASSISI_IMGUI_ROOT "${imgui_PACKAGE_FOLDER_DEBUG}")
-elseif(DEFINED imgui_PACKAGE_FOLDER_RELEASE)
-    set(ASSISI_IMGUI_ROOT "${imgui_PACKAGE_FOLDER_RELEASE}")
-else()
-    message(FATAL_ERROR "Cannot locate imgui package root — ensure imgui is installed via Conan.")
-endif()
+# --- Dear ImGui (docking branch, fetched from GitHub)
+include(FetchContent)
+FetchContent_Declare(
+    imgui
+    GIT_REPOSITORY https://github.com/ocornut/imgui.git
+    GIT_TAG        docking
+    GIT_SHALLOW    TRUE
+    DOWNLOAD_ONLY  YES
+)
+FetchContent_MakeAvailable(imgui)
+
+add_library(Assisi-ImGui STATIC
+    "${imgui_SOURCE_DIR}/imgui.cpp"
+    "${imgui_SOURCE_DIR}/imgui_draw.cpp"
+    "${imgui_SOURCE_DIR}/imgui_tables.cpp"
+    "${imgui_SOURCE_DIR}/imgui_widgets.cpp"
+    "${imgui_SOURCE_DIR}/imgui_demo.cpp"
+)
+target_include_directories(Assisi-ImGui PUBLIC "${imgui_SOURCE_DIR}")
+# ImGui doesn't use our strict warning flags, so don't apply Assisi defaults
+add_library(imgui::imgui ALIAS Assisi-ImGui)
+
+set(ASSISI_IMGUI_ROOT "${imgui_SOURCE_DIR}")
 
 add_library(Assisi-Deps INTERFACE)
 add_library(Assisi::Deps ALIAS Assisi-Deps)

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -5,7 +5,6 @@ assimp/5.4.3
 stb/cci.20230920
 glad/0.1.36
 joltphysics/5.2.0
-imgui/1.92.5
 nlohmann_json/3.11.3
 
 [options]

--- a/modules/Debug/CMakeLists.txt
+++ b/modules/Debug/CMakeLists.txt
@@ -7,8 +7,8 @@ target_sources(Assisi-Debug
   PRIVATE
     "src/DebugUI.cpp"
     # Dear ImGui platform/renderer backends (compiled as part of this module)
-    "${ASSISI_IMGUI_ROOT}/res/bindings/imgui_impl_glfw.cpp"
-    "${ASSISI_IMGUI_ROOT}/res/bindings/imgui_impl_opengl3.cpp"
+    "${ASSISI_IMGUI_ROOT}/backends/imgui_impl_glfw.cpp"
+    "${ASSISI_IMGUI_ROOT}/backends/imgui_impl_opengl3.cpp"
 )
 
 target_include_directories(Assisi-Debug
@@ -16,7 +16,7 @@ target_include_directories(Assisi-Debug
     "${CMAKE_CURRENT_SOURCE_DIR}/include"
   PRIVATE
     # Backend headers live alongside their source files
-    "${ASSISI_IMGUI_ROOT}/res/bindings"
+    "${ASSISI_IMGUI_ROOT}/backends"
 )
 
 target_link_libraries(Assisi-Debug

--- a/modules/Debug/src/DebugUI.cpp
+++ b/modules/Debug/src/DebugUI.cpp
@@ -20,6 +20,8 @@ void DebugUI::Initialize(const Window::WindowContext &window)
 
     ImGuiIO &io = ImGui::GetIO();
     io.ConfigFlags |= ImGuiConfigFlags_NavEnableKeyboard;
+    io.ConfigFlags |= ImGuiConfigFlags_DockingEnable;
+    io.ConfigFlags |= ImGuiConfigFlags_ViewportsEnable;
 
     ImGui::StyleColorsDark();
 
@@ -46,6 +48,15 @@ void DebugUI::EndFrame()
 {
     ImGui::Render();
     ImGui_ImplOpenGL3_RenderDrawData(ImGui::GetDrawData());
+
+    ImGuiIO &io = ImGui::GetIO();
+    if (io.ConfigFlags & ImGuiConfigFlags_ViewportsEnable)
+    {
+        GLFWwindow *backupContext = glfwGetCurrentContext();
+        ImGui::UpdatePlatformWindows();
+        ImGui::RenderPlatformWindowsDefault();
+        glfwMakeContextCurrent(backupContext);
+    }
 }
 
 } // namespace Assisi::Debug


### PR DESCRIPTION
Removed imgui from conanfile.txt
Obtaining imgui through cmake since conan only tracks the master branch. Enabled imgui's docking features