### PR TITLE
fix(build): the tsan suite fails for our races, not somebody else's

### DIFF
--- a/.tsan-suppressions
+++ b/.tsan-suppressions
@@ -1,0 +1,50 @@
+# ThreadSanitizer suppressions.
+#
+# Third-party only. Nothing in here may name an Assisi symbol or file: the point
+# of the tsan target is to fail when *we* introduce a race, and a suppression
+# that reaches our code turns the gate off without anyone noticing. If a report
+# can be fixed in our source, fix it instead of adding a line here.
+#
+# Jolt is deliberately absent. Its solver's races were removed rather than
+# suppressed — a sanitized build steps physics on Jolt's single-threaded job
+# system (modules/Physics/src/PhysicsWorld.cpp, ASSISI_PHYSICS_TSAN).
+
+# --- GameNetworkingSockets -------------------------------------------------
+#
+# Not suppressed here — the deadlock detector is off instead, in the tsan test
+# presets (`detect_deadlocks=0`, CMakePresets.json). This block records why,
+# because turning a detector off deserves an argument.
+#
+# Every inversion the suite produces is between GNS's global lock and its
+# per-connection locks. The hierarchy is GNS's own and deliberate: its source
+# states that holding the global lock while taking a connection lock is
+# intended. We reach both sides only through its public API —
+# Connect()/CreateLoopbackPair() call ConnectByIPAddress, and Adopt() calls
+# SetConnectionPollGroup/ConfigureConnectionLanes from inside a GNS status
+# callback that already holds the global lock. Neither mutex is ours and
+# neither order is ours to choose. (tsan is also known to report inversions
+# against correct code when timed locks are involved — llvm#57955,
+# google/sanitizers#814 — and GNS's global lock is a recursive_timed_mutex;
+# every one of these traces goes through pthread_mutex_clocklock.)
+#
+# A suppression scoped to GNS was tried and does not work: tsan's deadlock
+# detector unwinds lock stacks with the fast unwinder and drops GNS's frames
+# entirely, leaving `recursive_timed_mutex::lock` sitting directly under *our*
+# call site. Building GNS with `-g -fno-omit-frame-pointer` was tried too
+# (verified applied, verified rebuilt) and does not bring them back. So the
+# only symbol a `deadlock:` line could match is Assisi code, which would blind
+# the detector in exactly the files that do the most locking.
+#
+# What is lost: inversions among our own mutexes, of which we have very few
+# (Blueprint.cpp's cache lock, NetTransport's g_libraryMutex). What is kept:
+# the data-race detector, which is what actually finds our bugs. Drop
+# `detect_deadlocks=0` for a deliberate lock-ordering audit and read past the
+# GNS noise by hand.
+
+# --- doctest ---------------------------------------------------------------
+#
+# doctest's crash handler builds a message with std::string and operator new
+# while inside the signal handler. Its own reporting path, reached only when a
+# test has already failed hard.
+signal:doctest::
+signal:handleSignal

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -304,6 +304,15 @@
       "execution": { "noTestsAction": "error", "stopOnFailure": false }
     },
 
+    {
+      "name": "tsan-base",
+      "hidden": true,
+      "inherits": "test-base",
+      "environment": {
+        "TSAN_OPTIONS": "suppressions=${sourceDir}/.tsan-suppressions detect_deadlocks=0 halt_on_error=0"
+      }
+    },
+
     { "name": "msvc-debug",  "inherits": "test-base", "configurePreset": "msvc-debug"  },
     { "name": "msvc-dev",    "inherits": "test-base", "configurePreset": "msvc-dev"    },
     { "name": "msvc-ship",   "inherits": "test-base", "configurePreset": "msvc-ship"   },
@@ -318,9 +327,9 @@
 
     { "name": "msvc-asan",   "inherits": "test-base", "configurePreset": "msvc-asan"   },
     { "name": "gcc-asan",    "inherits": "test-base", "configurePreset": "gcc-asan"    },
-    { "name": "gcc-tsan",    "inherits": "test-base", "configurePreset": "gcc-tsan"    },
+    { "name": "gcc-tsan",    "inherits": "tsan-base", "configurePreset": "gcc-tsan"    },
     { "name": "clang-asan",  "inherits": "test-base", "configurePreset": "clang-asan"  },
-    { "name": "clang-tsan",  "inherits": "test-base", "configurePreset": "clang-tsan"  },
+    { "name": "clang-tsan",  "inherits": "tsan-base", "configurePreset": "clang-tsan"  },
 
     { "name": "msvc-debug-chiara",  "inherits": "test-base", "configurePreset": "msvc-debug-chiara"  },
     { "name": "msvc-dev-chiara",    "inherits": "test-base", "configurePreset": "msvc-dev-chiara"    },
@@ -334,6 +343,6 @@
     { "name": "clang-dev-chiara",   "inherits": "test-base", "configurePreset": "clang-dev-chiara"   },
     { "name": "clang-ship-chiara",  "inherits": "test-base", "configurePreset": "clang-ship-chiara"  },
 
-    { "name": "gcc-tsan-chiara",    "inherits": "test-base", "configurePreset": "gcc-tsan-chiara"    }
+    { "name": "gcc-tsan-chiara",    "inherits": "tsan-base", "configurePreset": "gcc-tsan-chiara"    }
   ]
 }

--- a/docs/remaining-work.md
+++ b/docs/remaining-work.md
@@ -109,6 +109,33 @@ round-6 items that had been waiting on a decision are resolved in §5.
     inheriting its `-debug` preset, with matching build/test presets and
     `make gcc-asan` / `make test-gcc-tsan` targets. Deps don't link
     `Assisi::Sanitize`, so third-party code stays uninstrumented.
+  - **The tsan suite was red for third-party reasons and is now green**
+    (2026-08-07). Four targets failed — Net, NetSync, Physics, App — and not one
+    report was a race on our own data. The triage, so nobody redoes it:
+    - **Jolt** (`TempAllocator.h`, `JobSystem.h`). Its solver coordinates
+      workers through barriers tsan does not model as happens-before edges.
+      Those are *headers*, inlined into our instrumented TUs, which is how they
+      reach the sanitizer at all despite the dep not linking `Assisi::Sanitize`.
+      **Removed, not suppressed:** a sanitized build steps physics on
+      `JPH::JobSystemSingleThreaded` (`PhysicsWorld.cpp`, `ASSISI_PHYSICS_TSAN`).
+      Jolt's results do not depend on worker count, so the same physics is
+      exercised; everything around it still runs threaded. Reproduces
+      identically under gcc *and* clang, so it is not a toolchain artefact.
+    - **GameNetworkingSockets** — lock-order-inversion between its global lock
+      and its per-connection locks, an ordering its own source documents as
+      intended, reached only through its public API. Not suppressible: tsan's
+      deadlock detector drops GNS's frames with the fast unwinder, and building
+      GNS with `-g -fno-omit-frame-pointer` does not bring them back (tried,
+      verified applied, reverted). So the deadlock detector is off
+      (`detect_deadlocks=0`); the race detector, which is what finds our bugs,
+      stays on. See `.tsan-suppressions` for the full argument.
+    - **doctest's signal handler** — allocates inside the handler. Suppressed.
+    - Two genuine bugs of ours fell out of the triage and are fixed: a forked
+      child kept the parent's signal handlers until `execv` (`ChildProcess.cpp`),
+      and `TestWorld`'s pool-sharing check assumed a threaded job system.
+    - The gate was verified to still bite: with `Blueprint.cpp`'s cache mutex
+      removed, tsan reports 458 data races in Assisi code. Re-verify that way
+      after touching the suppressions.
   - **`-ffast-math` split** resolved in `5da431a`: now applies to Release *and*
     RelWithDebInfo, with `-fno-finite-math-only` appended so the non-finite
     guards stay live (verified empirically — under plain `-ffast-math` an

--- a/modules/App/src/ChildProcess.cpp
+++ b/modules/App/src/ChildProcess.cpp
@@ -107,6 +107,19 @@ bool ChildProcess::Spawn(const std::filesystem::path &executable, const std::vec
     if (pid == 0)
     {
         // --- child ---------------------------------------------------------
+        // First, before anything that can take time. Until execv replaces the
+        // image the child still carries the *parent's* signal handlers, and a
+        // signal arriving in that window runs the parent's handler in the child
+        // — with the parent's atexit chain behind it. Terminate() sends SIGTERM
+        // and can easily beat exec: the window is short, but a sanitized build
+        // widens it enough that the test suite hits it every run, where the
+        // handler doctest installed reported a crash and printed a second,
+        // partial test summary from a process that was never a test runner.
+        // The editor spawning and immediately closing a play-in-editor client
+        // is the same shape.
+        for (int sig = 1; sig < NSIG; ++sig)
+            ::signal(sig, SIG_DFL); // EINVAL on the unmaskable ones; nothing to do about those
+
 #if defined(__linux__)
         // The one case the parent cannot clean up from its own side. Without
         // this, an editor that crashes (or is killed with -9) leaves its viewer

--- a/modules/App/tests/TestWorld.cpp
+++ b/modules/App/tests/TestWorld.cpp
@@ -6,6 +6,16 @@
 
 #include <doctest/doctest.h>
 
+// A ThreadSanitizer build steps physics on Jolt's single-threaded job system, so
+// there is no pool to spin up — see PhysicsWorld.cpp's JoltRuntime for why.
+#if defined(__SANITIZE_THREAD__)
+#    define ASSISI_APP_TSAN 1
+#elif defined(__has_feature)
+#    if __has_feature(thread_sanitizer)
+#        define ASSISI_APP_TSAN 1
+#    endif
+#endif
+
 #include <chrono>
 #include <cstddef>
 #include <filesystem>
@@ -147,10 +157,17 @@ TEST_CASE("Resident worlds share one physics thread pool")
     // Guard against the test passing vacuously: on a multi-core machine the
     // first world must actually have spun the pool up, or "no growth" below
     // would prove nothing.
+    //
+    // Except under tsan, where the pool is deliberately Jolt's single-threaded
+    // job system and there is nothing to spin up. The check below still means
+    // something there — it is the one that would catch a pool per world — but
+    // this guard cannot, so it is skipped rather than weakened for every build.
+#if !defined(ASSISI_APP_TSAN)
     if (std::thread::hardware_concurrency() > 1u)
     {
         REQUIRE(afterFirst > baseline);
     }
+#endif
 
     for (int32_t i = 0; i < 4; ++i)
     {

--- a/modules/Core/include/Assisi/Core/Reflect/ComponentRegistry.hpp
+++ b/modules/Core/include/Assisi/Core/Reflect/ComponentRegistry.hpp
@@ -13,6 +13,7 @@
 /// table is also immutable after startup and read-only at runtime, so shared
 /// process-wide state carries no ordering or test-isolation hazard.
 
+#include <atomic>
 #include <span>
 #include <string_view>
 #include <typeindex>
@@ -107,7 +108,10 @@ class ComponentRegistry
     /// the whole table so the hot lookup is an index rather than a search.
     mutable std::vector<std::size_t>                          _replicableOrdinal;
     mutable std::unordered_map<std::type_index, ComponentId>  _idByType;
-    mutable bool                                              _finalized = false;
+    /// Atomic because finalization is lazy and the first ask can come from any
+    /// thread: async travel deserializes on a worker and walks this registry
+    /// there, while the main thread is doing the same. See EnsureFinalized.
+    mutable std::atomic<bool>                                 _finalized{false};
 };
 
 } // namespace Assisi::Core::Reflect

--- a/modules/Core/src/ComponentRegistry.cpp
+++ b/modules/Core/src/ComponentRegistry.cpp
@@ -6,7 +6,17 @@
 #include <Assisi/Core/Reflect/ReplicableLimits.hpp>
 
 #include <algorithm>
+#include <mutex>
 #include <utility>
+
+namespace
+{
+/// Guards the one-time finalization below. A file static rather than a member so
+/// <mutex> stays out of a header most of the engine includes; the registry is a
+/// singleton, and a second instance in a test sharing this lock is merely
+/// coarser, never wrong.
+std::mutex g_finalizeMutex;
+} // namespace
 
 namespace Assisi::Core::Reflect
 {
@@ -39,7 +49,7 @@ void ComponentRegistry::Register(ComponentMeta meta)
     // genuine bug, so this is loud in debug and a dropped component in release —
     // a component that is absent fails visibly at Find(), whereas renumbering
     // silently mis-maps every id in the process.
-    if (_finalized)
+    if (_finalized.load(std::memory_order_acquire))
     {
         // Log first, assert second: the assert does not return — it aborts (or, under
         // the test handler, throws) — so anything after it is unreachable in debug.
@@ -60,7 +70,20 @@ void ComponentRegistry::Register(ComponentMeta meta)
 
 void ComponentRegistry::EnsureFinalized() const
 {
-    if (_finalized)
+    // Acquire, and it is the whole point: a thread that sees the flag set must
+    // also see every table the finalizing thread built below. A plain bool here
+    // was a data race — the sort, the id assignment and the _serializable /
+    // _replicable vectors are all written under it, and the first ask can come
+    // from a worker (async travel deserializes off the main thread and walks
+    // this registry there) while the main thread asks for the same thing.
+    if (_finalized.load(std::memory_order_acquire))
+        return;
+
+    const std::lock_guard lock(g_finalizeMutex);
+
+    // Re-checked under the lock: the loser of the race would otherwise sort and
+    // re-id a table the winner has already handed pointers into.
+    if (_finalized.load(std::memory_order_relaxed))
         return;
 
     std::sort(_metas.begin(), _metas.end(),
@@ -124,7 +147,9 @@ void ComponentRegistry::EnsureFinalized() const
                          _replicable.size(), kReplicableComponentCount);
     }
 
-    _finalized = true;
+    // Release, pairing with the acquire above: everything written in this
+    // function happens-before any thread that observes the flag set.
+    _finalized.store(true, std::memory_order_release);
 }
 
 std::span<const ComponentMeta *const> ComponentRegistry::ReplicableComponents() const

--- a/modules/Core/tests/TestComponentRegistry.cpp
+++ b/modules/Core/tests/TestComponentRegistry.cpp
@@ -225,3 +225,109 @@ TEST_CASE("ComponentRegistry: duplicate component names are rejected, not both k
 
     CHECK(count == 1); // no uniqueness check → both duplicates persist
 }
+
+// ---------------------------------------------------------------------------
+// EnsureFinalized's thread safety — verified, but not compilable as it stands
+// ---------------------------------------------------------------------------
+//
+// Finalization is lazy: the first ask sorts _metas, drops duplicates, assigns
+// every id and fills _serializable/_replicable/_replicableOrdinal. The first ask
+// can come from any thread — async travel deserializes on a worker and walks
+// this registry there while the main thread does too — so it is a one-time
+// initialization and needs to say so. It now does: an atomic flag with
+// acquire/release plus a double-checked lock.
+//
+// **This case cannot be compiled here.** It needs a registry that has *never*
+// been queried, and the only one this file can reach is Instance(), which
+// earlier cases in this binary have already finalized — every thread would take
+// the fast path and the case would pass whether or not the lock exists. That
+// exact vacuous version was written first and caught by removing the lock and
+// getting zero reports. A fresh registry is what makes it real, and
+// ComponentRegistry() is private on purpose (one registry per process).
+//
+// It was run, by making that constructor public temporarily:
+//   * with the lock — clean under `make gcc-tsan`;
+//   * with the `lock_guard` in EnsureFinalized removed — 393 data races,
+//     naming ComponentRegistry.cpp's sort comparator and ComponentMeta's move
+//     constructor/assignment, i.e. two threads sorting the same vector.
+//
+// To re-run it: make ComponentRegistry() public, uncomment below, add <atomic>,
+// <cstdint>, <string>, <thread> and <vector>, then `make test-gcc-tsan`. To keep
+// it permanently instead, it needs its own test binary — nothing else linked
+// into it may query the registry — following the Assisi-Chiara-PreInit-Tests
+// pattern in modules/Chiara/tests/CMakeLists.txt, which exists for the same
+// reason ("Initialize has not been called yet" cannot hold in a shared process).
+//
+// TEST_CASE("ComponentRegistry: racing the first finalize is safe")
+// {
+//     ComponentRegistry registry;
+//
+//     // Enough entries that the sort is not a single compare — the wider the
+//     // finalize window, the more reliably two threads are inside it at once.
+//     // Deliberately not in name order, so the sort actually moves things.
+//     std::vector<std::string> names;
+//     names.reserve(64);
+//     for (std::int32_t i = 63; i >= 0; --i)
+//         names.push_back("Race" + std::string(i < 10 ? "0" : "") + std::to_string(i));
+//     for (const std::string &name : names)
+//         registry.Register(Meta(name.c_str(), typeid(RegAlpha))); // typeIndex is not under test
+//
+//     constexpr std::int32_t kThreads = 8;
+//
+//     // Released together, so they arrive at EnsureFinalized simultaneously
+//     // rather than one winning outright and the rest taking the fast path.
+//     std::atomic<bool>         go{false};
+//     std::atomic<std::int32_t> ready{0};
+//     std::atomic<std::int32_t> disagreements{0};
+//     std::vector<std::thread>  workers;
+//     workers.reserve(kThreads);
+//
+//     for (std::int32_t index = 0; index < kThreads; ++index)
+//     {
+//         workers.emplace_back(
+//             [index, &registry, &go, &ready, &disagreements]
+//             {
+//                 ready.fetch_add(1, std::memory_order_release);
+//                 while (!go.load(std::memory_order_acquire))
+//                 {
+//                 }
+//
+//                 // A different finalizing entry point per thread, so whichever
+//                 // one wins, the others are inside a different accessor.
+//                 switch (index % 3)
+//                 {
+//                 case 0:
+//                     if (registry.All().size() != 64)
+//                         disagreements.fetch_add(1, std::memory_order_relaxed);
+//                     break;
+//                 case 1:
+//                     if (registry.SerializableComponents().size() != 64)
+//                         disagreements.fetch_add(1, std::memory_order_relaxed);
+//                     break;
+//                 default:
+//                     if (registry.IdOf("Race00") == kInvalidComponentId)
+//                         disagreements.fetch_add(1, std::memory_order_relaxed);
+//                     break;
+//                 }
+//
+//                 // Ids are handed out during finalization, so a half-numbered
+//                 // or re-sorted table shows up here.
+//                 for (const auto &meta : registry.All())
+//                 {
+//                     if (registry.ById(meta.id) != &meta)
+//                         disagreements.fetch_add(1, std::memory_order_relaxed);
+//                 }
+//             });
+//     }
+//
+//     while (ready.load(std::memory_order_acquire) < kThreads)
+//     {
+//     }
+//     go.store(true, std::memory_order_release);
+//
+//     for (std::thread &worker : workers)
+//         worker.join();
+//
+//     CHECK(disagreements.load(std::memory_order_relaxed) == 0);
+//     CHECK(registry.All().size() == 64);
+// }

--- a/modules/Physics/src/PhysicsWorld.cpp
+++ b/modules/Physics/src/PhysicsWorld.cpp
@@ -8,7 +8,17 @@
 
 #include <Jolt/Jolt.h>
 
+// A sanitized build steps physics on one thread — see kSanitized below for why.
+#if defined(__SANITIZE_THREAD__)
+#    define ASSISI_PHYSICS_TSAN 1
+#elif defined(__has_feature)
+#    if __has_feature(thread_sanitizer)
+#        define ASSISI_PHYSICS_TSAN 1
+#    endif
+#endif
+
 #include <Jolt/Core/Factory.h>
+#include <Jolt/Core/JobSystemSingleThreaded.h>
 #include <Jolt/Core/JobSystemThreadPool.h>
 #include <Jolt/Core/TempAllocator.h>
 #include <Jolt/Physics/Body/BodyActivationListener.h>
@@ -139,8 +149,30 @@ class ObjLayerFilter final : public JPH::ObjectLayerPairFilter
    allocator is 10 MiB of scratch each — cheap — and makes stepping safe whether
    worlds run sequentially or (later) in parallel. The pool stays shared; Jolt is
    built for many PhysicsSystems on one JobSystem. */
+/* Under ThreadSanitizer the pool is replaced by Jolt's single-threaded job
+   system. Jolt's solver coordinates its workers through its own barriers and
+   atomics rather than through anything tsan models as a happens-before edge, so
+   a threaded step reports races inside `JobSystem.h` and `TempAllocator.h` —
+   Jolt's own headers, which reach the instrumentation only because they are
+   headers inlined into this TU (the Jolt library itself does not link
+   Assisi::Sanitize). Those reports are not ours and cannot be fixed here, and
+   left alone they bury any real race in noise: four suites go red for reasons
+   nobody can act on, which is the same as having no tsan gate at all.
+
+   Stepping on one thread removes them at the source rather than hiding them
+   behind a suppression. It costs nothing that matters — Jolt's results do not
+   depend on worker count, so a sanitized run exercises the same physics, just
+   more slowly, which a sanitized build is anyway. Everything *around* physics
+   still runs threaded, so the async-travel worker, the job system and the
+   blueprint cache are all still under test. Speed is not a question a sanitized
+   build answers (see Chiara's TestOverhead for the same reasoning). */
 struct JoltRuntime
 {
+#if defined(ASSISI_PHYSICS_TSAN)
+    JPH::JobSystemSingleThreaded jobSystem;
+
+    JoltRuntime() { jobSystem.Init(JPH::cMaxPhysicsJobs); }
+#else
     // Default-constructed and then Init'd in the body rather than built by the
     // thread-starting constructor: Jolt requires the thread-init function to be
     // set *before* Init, and setting it afterwards compiles fine while silently
@@ -156,6 +188,7 @@ struct JoltRuntime
         jobSystem.Init(JPH::cMaxPhysicsJobs, JPH::cMaxPhysicsBarriers,
                        static_cast<int>(std::thread::hardware_concurrency()) - 1);
     }
+#endif
 };
 
 /// Jolt allocation counters. Churn per frame, not residency: JPH::FreeFunction
@@ -235,8 +268,14 @@ class JoltRuntimeRef
             JPH::Factory::sInstance = new JPH::Factory();
             JPH::RegisterTypes();
             gJoltRuntime = new JoltRuntime();
-            Assisi::Core::Log::Info("Jolt: runtime up ({} worker threads, shared by every physics world).",
-                                    gJoltRuntime->jobSystem.GetMaxConcurrency());
+            Assisi::Core::Log::Info("Jolt: runtime up ({} worker thread(s), shared by every physics world){}.",
+                                    gJoltRuntime->jobSystem.GetMaxConcurrency(),
+#if defined(ASSISI_PHYSICS_TSAN)
+                                    " — single-threaded, this is a ThreadSanitizer build"
+#else
+                                    ""
+#endif
+            );
         }
     }
 
@@ -255,7 +294,9 @@ class JoltRuntimeRef
     JoltRuntimeRef(const JoltRuntimeRef &) = delete;
     JoltRuntimeRef &operator=(const JoltRuntimeRef &) = delete;
 
-    JPH::JobSystemThreadPool &JobSystem() const { return gJoltRuntime->jobSystem; }
+    // The base type, so the tsan build's single-threaded job system substitutes
+    // without every caller caring which one it got.
+    JPH::JobSystem &JobSystem() const { return gJoltRuntime->jobSystem; }
 };
 
 } // anonymous namespace


### PR DESCRIPTION
…l lights

Replaces the single hardcoded directional light uniform with a full
clustered forward pipeline. The view frustum is subdivided into a 16x9x24
grid; a compute pass assigns lights to clusters each frame so fragment
shaders only iterate lights that touch their cluster.

- ComputeShader: single-stage compute shader wrapper
- ClusterGrid: manages cluster AABB SSBOs, light data SSBOs, and both
  compute passes (cluster_build.comp, cluster_cull.comp)
- LightComponents: DirectionalLightComponent, PointLightComponent,
  SpotLightComponent ECS components
- LightingSystem: queries light components from the scene, uploads to GPU,
  runs cull pass; exposes SetupMeshShader for static cluster uniforms
- mesh.frag/vert: SSBO-based light lookup with Cook-Torrance BRDF per
  light type; windowed inverse-square attenuation for point/spot
- Shader: add SetUInt and SetUVec3
- conanfile.txt: bump glad to OpenGL 4.6 (required for compute shaders,
  SSBOs, and DSA buffer functions)
- Sandbox: sun entity, three PBR test cubes, three coloured point lightsFour targets were red under ThreadSanitizer — Net, NetSync, Physics, App —
and not one report was a race on our own data. A gate that is red for
reasons nobody can act on is the same as no gate at all: the ENG-96 cache
race would have landed in the noise.

Jolt: its solver coordinates workers through barriers tsan does not model as
happens-before edges, so `TempAllocator.h` and `JobSystem.h` report races.
They are headers, inlined into our instrumented TUs, which is the only reason
they reach the sanitizer at all — the dep itself never links Assisi::Sanitize.
Removed rather than suppressed: a sanitized build steps physics on
JobSystemSingleThreaded. Jolt's results do not depend on worker count, so the
same physics runs, and everything around it stays threaded. Reproduces
identically under gcc and clang, so it was never a toolchain artefact.

GameNetworkingSockets: lock-order-inversion between its global lock and its
per-connection locks, an order its own source documents as intended and which
we reach only through its public API. It cannot be suppressed by third-party
symbol — tsan's deadlock detector drops GNS's frames with the fast unwinder,
leaving `recursive_timed_mutex::lock` directly under *our* call site, and
building GNS with -g -fno-omit-frame-pointer does not bring them back (tried,
verified applied, reverted). Matching on Assisi symbols instead would blind
the detector in the files that do the most locking, so the detector is off and
the race detector — the half that finds our bugs — stays on.

doctest allocates inside its signal handler; suppressed.

Two real bugs of ours fell out of the triage. A forked child kept the
parent's signal handlers until execv, so a signal landing in that window ran
the parent's handler in the child — the editor closing a just-spawned
play-in-editor client is the same shape. And TestWorld's pool-sharing check
asserted the first world spins up threads, which the single-threaded job
system makes false; its second assertion still catches a pool per world.

Verified the gate still bites: with Blueprint.cpp's cache mutex removed, tsan
reports 458 data races in Assisi code. Green across gcc-tsan, clang-tsan,
gcc-debug and gcc-asan.